### PR TITLE
perf(desktop): restore differential downloads and speed up installs

### DIFF
--- a/.github/workflows/desktop-package-smoke.yml
+++ b/.github/workflows/desktop-package-smoke.yml
@@ -57,3 +57,17 @@ jobs:
           path: ${{ runner.temp }}/catsco-desktop-smoke/reports
           retention-days: 7
           if-no-files-found: warn
+      - name: Upload Windows update fixture installers and blockmaps
+        if: success() && runner.os == 'Windows'
+        uses: actions/upload-artifact@v4
+        with:
+          name: desktop-update-fixtures
+          compression-level: 0
+          retention-days: 2
+          path: |
+            ${{ runner.temp }}/catsco-desktop-smoke/0.0.1/*.exe
+            ${{ runner.temp }}/catsco-desktop-smoke/0.0.1/*.blockmap
+            ${{ runner.temp }}/catsco-desktop-smoke/0.0.1/latest.yml
+            ${{ runner.temp }}/catsco-desktop-smoke/0.0.2/*.exe
+            ${{ runner.temp }}/catsco-desktop-smoke/0.0.2/*.blockmap
+            ${{ runner.temp }}/catsco-desktop-smoke/0.0.2/latest.yml

--- a/.github/workflows/desktop-package-smoke.yml
+++ b/.github/workflows/desktop-package-smoke.yml
@@ -1,0 +1,59 @@
+name: Desktop package smoke
+on:
+  pull_request:
+    paths:
+      - 'electron/**'
+      - 'electron-builder.config.cjs'
+      - 'package*.json'
+      - 'scripts/*runtime*'
+      - 'scripts/*electron*'
+      - 'scripts/desktop-*'
+      - '.github/workflows/desktop-package-smoke.yml'
+  workflow_dispatch:
+permissions:
+  contents: read
+concurrency:
+  group: desktop-smoke-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  package:
+    name: Packaged runtime (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-2022, macos-15-intel, macos-15, ubuntu-24.04]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - uses: actions/cache@v4
+        with:
+          path: .cache/runtime-downloads
+          key: smoke-runtime-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('scripts/runtime-manifest.json') }}
+      - run: npm ci --prefer-offline --no-audit --fund=false
+      - run: npm run build
+      - run: npm run prepare:runtime
+      - run: npm run prune:electron-optionals
+      - name: Linux display and packaging dependencies
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y xvfb libgtk-3-0t64 libnss3 libasound2t64 rpm
+      - name: Exercise final packages
+        shell: bash
+        run: |
+          if [ "$RUNNER_OS" = "Linux" ]; then
+            xvfb-run -a node scripts/desktop-package-smoke.mjs
+          else
+            node scripts/desktop-package-smoke.mjs
+          fi
+      - name: Upload package acceptance evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: desktop-smoke-${{ matrix.os }}
+          path: ${{ runner.temp }}/catsco-desktop-smoke/reports
+          retention-days: 7
+          if-no-files-found: warn

--- a/docs/AUTO_UPDATE.md
+++ b/docs/AUTO_UPDATE.md
@@ -22,6 +22,28 @@
 
 只有当这套 tag 驱动的 CD 成功完成后，客户端自动更新链路才是完整可用的。
 
+## Windows 差分更新
+
+Windows NSIS 产物显式启用 `differentialPackage`，发布时必须同时保留
+`latest.yml`、当前和上一版本的 `.exe.blockmap` 以及对应安装包。
+
+正式更新源是火山引擎 TOS。该对象存储支持单段 HTTP Range，但多段 Range
+请求会返回整个对象，因此 generic provider 必须设置
+`useMultipleRangeRequest: false`。这样 electron-updater 会按变化块发起单段
+Range 请求，避免差分更新退化为下载完整安装包。
+
+差分下载会在本地重建并校验完整 NSIS 安装器；NSIS 随后仍会更新应用目录。
+当前打包只保留 electron-builder 收集的生产依赖树，不再通过
+`extraResources` 复制第二套 `node_modules`，以减少安装阶段的文件展开和扫描。
+这些依赖由内置 Node 子进程加载，因此打包时关闭 Electron ABI 原生模块重编译；
+发布验收仍需从打包目录使用内置 Node 加载实际原生模块。
+
+发布验收必须检查应用 `userData` 目录下的 `logs/updater.log`：
+
+- 出现 `Differential download`，且实际传输量明显小于完整安装包，才算命中差分下载。
+- 出现 `fallback to full download` 时，记录具体错误并按完整包下载处理，不能把它标记为差分成功。
+- 下载完成后继续验证退出、安装器接管、重新启动和版本号，不能只看下载进度到 100%。
+
 ## macOS 的额外要求
 
 macOS 发布必须同时生成 `.dmg` 和 `.zip`：

--- a/docs/AUTO_UPDATE.md
+++ b/docs/AUTO_UPDATE.md
@@ -35,6 +35,7 @@ Range 请求，避免差分更新退化为下载完整安装包。
 差分下载会在本地重建并校验完整 NSIS 安装器；NSIS 随后仍会更新应用目录。
 当前打包只保留 electron-builder 收集的生产依赖树，不再通过
 `extraResources` 复制第二套 `node_modules`，以减少安装阶段的文件展开和扫描。
+桌面源码未使用、仅供 Worker 制品验收的 `deasync` 会在 `afterPack` 阶段移除。
 这些依赖由内置 Node 子进程加载，因此打包时关闭 Electron ABI 原生模块重编译；
 发布验收仍需从打包目录使用内置 Node 加载实际原生模块。
 

--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -16,6 +16,10 @@ function getPublishConfig() {
       {
         provider: "generic",
         url: updateBaseUrl,
+        // Volcengine TOS supports single byte-range requests, but responds to
+        // a multi-range request with the complete object. electron-updater
+        // otherwise downloads the full installer while attempting a delta.
+        useMultipleRangeRequest: false,
       },
       {
         provider: "github",

--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -1,4 +1,24 @@
+const fs = require("node:fs");
+const path = require("node:path");
 const packageJson = require("./package.json");
+
+const DESKTOP_EXCLUDED_PRODUCTION_DEPENDENCIES = ["deasync"];
+
+function removeDesktopExcludedDependencies(context) {
+  const resourcesDir = context.packager.getResourcesDir(context.appOutDir);
+  const appNodeModules = path.join(resourcesDir, "app", "node_modules");
+  const nodeModulesRoot = path.resolve(appNodeModules) + path.sep;
+
+  for (const packageName of DESKTOP_EXCLUDED_PRODUCTION_DEPENDENCIES) {
+    const packagePath = path.resolve(appNodeModules, packageName);
+    if (!packagePath.startsWith(nodeModulesRoot)) {
+      throw new Error(`Refusing to remove a desktop dependency outside node_modules: ${packagePath}`);
+    }
+    if (!fs.existsSync(packagePath)) continue;
+    fs.rmSync(packagePath, { recursive: true, force: true });
+    console.log(`Removed desktop-excluded production dependency: ${packageName}`);
+  }
+}
 
 function normalizeBaseUrl(value) {
   if (!value) {
@@ -40,4 +60,5 @@ function getPublishConfig() {
 module.exports = {
   ...packageJson.build,
   publish: getPublishConfig(),
+  afterPack: removeDesktopExcludedDependencies,
 };

--- a/electron/main.js
+++ b/electron/main.js
@@ -414,12 +414,12 @@ function getRuntimeRoot() {
 
 
 
-/**
- * 闂備礁鍚嬮崕鎶藉床閼艰翰浜?node_modules 闂佽崵濮崇拃锕傚垂閹殿喗顐介柣鎰劋閺咁剟鏌涢銈呮瀻闁愁亞鏁婚弻娑㈠冀瑜庨崳钘夘熆瑜庨〃濠傜暦?extraResources 濠电偞鍨堕幖鈺呭矗韫囨洘顫?
- */
+// electron-builder already places production dependencies beside the packaged
+// application. Keep one module tree instead of copying a second tree through
+// extraResources; the dashboard child process receives this path via NODE_PATH.
 function getNodeModulesPath() {
   if (app.isPackaged) {
-    return path.join(process.resourcesPath, 'node_modules');
+    return path.join(getAppRoot(), 'node_modules');
   }
   return path.join(__dirname, '..', 'node_modules');
 }

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
       "output": "release"
     },
     "asar": false,
+    "npmRebuild": false,
     "publish": {
       "provider": "github",
       "owner": "buildsense-ai",
@@ -112,6 +113,9 @@
     },
     "files": [
       "dist/**/*",
+      "!dist/**/*.d.ts",
+      "!dist/**/*.d.ts.map",
+      "!dist/**/*.js.map",
       "electron/**/*",
       "dashboard/**/*",
       "prompts/**/*",
@@ -122,27 +126,6 @@
       "skills/README.md",
       ".env.example",
       "package.json"
-    ],
-    "extraResources": [
-      {
-        "from": "node_modules",
-        "to": "node_modules",
-        "filter": [
-          "**/*.node",
-          "**/*.js",
-          "**/*.mjs",
-          "**/*.wasm",
-          "**/*.json",
-          "!**/.bin/**",
-          "!**/test/**",
-          "!**/tests/**",
-          "!**/*.md",
-          "!electron/**",
-          "!electron-builder/**",
-          "@types/**",
-          "!typescript/**"
-        ]
-      }
     ],
     "extraFiles": [
       {
@@ -177,7 +160,8 @@
       "oneClick": false,
       "allowToChangeInstallationDirectory": true,
       "createDesktopShortcut": true,
-      "shortcutName": "CatsCo"
+      "shortcutName": "CatsCo",
+      "differentialPackage": true
     },
     "linux": {
       "target": [

--- a/scripts/check-release-branding.mjs
+++ b/scripts/check-release-branding.mjs
@@ -47,6 +47,8 @@ function walk(relativeDir, results = []) {
 const packageJson = JSON.parse(readText('package.json'));
 assertEqual('build.productName', packageJson.build?.productName, 'CatsCo');
 assertEqual('build.nsis.shortcutName', packageJson.build?.nsis?.shortcutName, 'CatsCo');
+assertEqual('build.nsis.differentialPackage', packageJson.build?.nsis?.differentialPackage, true);
+assertEqual('build.npmRebuild', packageJson.build?.npmRebuild, false);
 assertEqual('build.dmg.title', packageJson.build?.dmg?.title, 'CatsCo');
 
 const macTargets = Array.isArray(packageJson.build?.mac?.target)

--- a/scripts/desktop-package-smoke.mjs
+++ b/scripts/desktop-package-smoke.mjs
@@ -88,6 +88,9 @@ async function waitForReport(version) {
       assert.equal(report.ok, true, JSON.stringify(report));
       return report;
     }
+    if ((!win || version === oldVersion) && child?.exitCode !== null && child?.exitCode !== undefined) {
+      throw new Error(`Packaged process exited ${child.exitCode} before reporting ${version}; see app.log`);
+    }
     await new Promise(resolve => setTimeout(resolve, 100));
   }
   throw new Error(`No successful startup report for ${version}`);
@@ -134,7 +137,10 @@ try {
       executable = path.join(scratch, 'squashfs-root', 'AppRun');
     }
     const log = fs.openSync(path.join(reports, 'app.log'), 'w');
-    child = spawn(executable, ['--no-sandbox'], { cwd: scratch, stdio: ['ignore', log, log] });
+    child = spawn(executable, ['--no-sandbox'], {
+      cwd: scratch, stdio: ['ignore', log, log],
+      env: { ...process.env, ...(!mac ? { APPDIR: path.join(scratch, 'squashfs-root') } : {}) },
+    });
     await waitForReport(newVersion);
     console.log(fs.readFileSync(path.join(reports, `${newVersion}.json`), 'utf8'));
   }

--- a/scripts/desktop-package-smoke.mjs
+++ b/scripts/desktop-package-smoke.mjs
@@ -58,11 +58,7 @@ async function run(exe, args, options = {}) {
 }
 async function packageVersion(version) {
   fs.writeFileSync(configFile, JSON.stringify(smokeConfig));
-  return build({
-    targets: platform.createTarget(win ? ['nsis'] : mac ? ['dmg', 'zip'] : ['AppImage', 'deb'], arch),
-    publish: 'never',
-    config: {
-      ...base,
+  const overrides = {
       appId: 'com.catcompany.desktop-smoke', productName: 'CatsCoSmoke',
       directories: { output: path.join(scratch, version) },
       extraMetadata: { name: 'catsco-desktop-smoke', version, main: 'electron/desktop-smoke-bootstrap.cjs' },
@@ -71,7 +67,14 @@ async function packageVersion(version) {
       nsis: { ...base.nsis, createDesktopShortcut: false, createStartMenuShortcut: false, runAfterFinish: false },
       mac: { ...base.mac, identity: null },
       afterSign: undefined,
-    },
+  };
+  // Pass one config file: programmatic overrides concatenate extraFiles with
+  // the auto-discovered config and attempt to copy runtime symlinks twice.
+  const builderConfig = path.join(scratch, 'electron-builder-smoke.cjs');
+  fs.writeFileSync(builderConfig, `module.exports = { ...require(${JSON.stringify(path.join(root, 'electron-builder.config.cjs'))}), ...${JSON.stringify(overrides)} };`);
+  return build({
+    targets: platform.createTarget(win ? ['nsis'] : mac ? ['dmg', 'zip'] : ['AppImage', 'deb'], arch),
+    publish: 'never', config: builderConfig,
   });
 }
 async function waitForReport(version) {

--- a/scripts/desktop-package-smoke.mjs
+++ b/scripts/desktop-package-smoke.mjs
@@ -12,6 +12,9 @@ assert.equal(process.env.GITHUB_ACTIONS, 'true', 'This installs an isolated smok
 const scratch = path.join(process.env.RUNNER_TEMP, 'catsco-desktop-smoke');
 const reports = path.join(scratch, 'reports');
 fs.mkdirSync(reports, { recursive: true });
+const bootstrap = path.join(root, 'electron', 'desktop-smoke-bootstrap.cjs');
+assert.equal(fs.existsSync(bootstrap), false, 'Refuse to overwrite an existing app entry');
+fs.copyFileSync(path.join(root, 'scripts', 'desktop-smoke-bootstrap.cjs'), bootstrap);
 const win = process.platform === 'win32';
 const mac = process.platform === 'darwin';
 const oldVersion = '0.0.1';
@@ -62,7 +65,6 @@ async function packageVersion(version) {
       appId: 'com.catcompany.desktop-smoke', productName: 'CatsCoSmoke',
       directories: { output: path.join(scratch, version) },
       extraMetadata: { name: 'catsco-desktop-smoke', version, main: 'electron/desktop-smoke-bootstrap.cjs' },
-      files: [...base.files, { from: 'scripts/desktop-smoke-bootstrap.cjs', to: 'electron/desktop-smoke-bootstrap.cjs' }],
       extraResources: [{ from: configFile, to: 'desktop-smoke.json' }],
       nsis: { ...base.nsis, createDesktopShortcut: false, createStartMenuShortcut: false, runAfterFinish: false },
       mac: { ...base.mac, identity: null },
@@ -138,5 +140,6 @@ try {
 } finally {
   server.close();
   if (child && child.exitCode === null) child.kill();
+  fs.unlinkSync(bootstrap);
   // Runner disposal removes installation/cache; reports survive via artifact upload.
 }

--- a/scripts/desktop-package-smoke.mjs
+++ b/scripts/desktop-package-smoke.mjs
@@ -74,7 +74,9 @@ async function packageVersion(version) {
   // the auto-discovered config and attempt to copy runtime symlinks twice.
   // CommonJS configs are cached by filename inside electron-builder.
   const builderConfig = path.join(scratch, `electron-builder-smoke-${version}.cjs`);
-  fs.writeFileSync(builderConfig, `module.exports = { ...require(${JSON.stringify(path.join(root, 'electron-builder.config.cjs'))}), ...${JSON.stringify(overrides)} };`);
+  // Builder normalizes arrays in place. Each build needs independent data as
+  // well as its own filename; preserve the afterPack function separately.
+  fs.writeFileSync(builderConfig, `const base = require(${JSON.stringify(path.join(root, 'electron-builder.config.cjs'))}); module.exports = { ...JSON.parse(JSON.stringify(base)), afterPack: base.afterPack, ...${JSON.stringify(overrides)} };`);
   return build({
     targets: platform.createTarget(win ? ['nsis'] : mac ? ['dmg', 'zip'] : ['AppImage', 'deb'], arch),
     publish: 'never', config: builderConfig,

--- a/scripts/desktop-package-smoke.mjs
+++ b/scripts/desktop-package-smoke.mjs
@@ -1,0 +1,139 @@
+// CI-only: real packages, native addons in both hosts, and Windows NSIS update.
+import fs from 'node:fs';
+import path from 'node:path';
+import http from 'node:http';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+const require = createRequire(import.meta.url);
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+assert.equal(process.env.GITHUB_ACTIONS, 'true', 'This installs an isolated smoke app only on disposable GitHub runners');
+const scratch = path.join(process.env.RUNNER_TEMP, 'catsco-desktop-smoke');
+const reports = path.join(scratch, 'reports');
+fs.mkdirSync(reports, { recursive: true });
+const win = process.platform === 'win32';
+const mac = process.platform === 'darwin';
+const oldVersion = '0.0.1';
+const newVersion = '0.0.2';
+const served = new Map();
+const requests = [];
+let fullBytes = 0;
+let rangeBytes = 0;
+const server = http.createServer((req, res) => {
+  const name = decodeURIComponent(new URL(req.url, 'http://localhost').pathname.slice(1));
+  const file = served.get(name);
+  if (!file) { res.writeHead(404).end(); return; }
+  const size = fs.statSync(file).size;
+  const match = /^bytes=(\d+)-(\d+)$/.exec(req.headers.range || '');
+  const start = match ? Number(match[1]) : 0;
+  const end = match ? Number(match[2]) : size - 1;
+  if (end >= size || start > end) { res.writeHead(416).end(); return; }
+  const bytes = end - start + 1;
+  requests.push({ name, range: req.headers.range || null, bytes });
+  if (name.endsWith('.exe')) { if (match) rangeBytes += bytes; else fullBytes += bytes; }
+  // TOS behaviour: single ranges work, multi-ranges receive the full object.
+  res.writeHead(match ? 206 : 200, {
+    'Content-Length': bytes, 'Accept-Ranges': 'bytes',
+    ...(match ? { 'Content-Range': `bytes ${start}-${end}/${size}` } : {}),
+  });
+  fs.createReadStream(file, { start, end }).pipe(res);
+});
+await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+process.env.XIAOBA_UPDATE_BASE_URL = `http://127.0.0.1:${server.address().port}`;
+process.env.CSC_IDENTITY_AUTO_DISCOVERY = 'false';
+const configFile = path.join(scratch, 'desktop-smoke.json');
+const smokeConfig = { reportDir: reports, dashboardPort: 18389, update: win, oldVersion };
+const { build, Platform, Arch } = require('electron-builder');
+const base = require('../electron-builder.config.cjs');
+const platform = win ? Platform.WINDOWS : mac ? Platform.MAC : Platform.LINUX;
+const arch = process.arch === 'arm64' ? Arch.arm64 : Arch.x64;
+let child;
+async function run(exe, args, options = {}) {
+  const proc = spawn(exe, args, { cwd: root, stdio: 'inherit', ...options });
+  await new Promise((resolve, reject) => {
+    proc.once('error', reject);
+    proc.once('exit', code => code === 0 ? resolve() : reject(new Error(`${exe} exited ${code}`)));
+  });
+}
+async function packageVersion(version) {
+  fs.writeFileSync(configFile, JSON.stringify(smokeConfig));
+  return build({
+    targets: platform.createTarget(win ? ['nsis'] : mac ? ['dmg', 'zip'] : ['AppImage', 'deb'], arch),
+    publish: 'never',
+    config: {
+      ...base,
+      appId: 'com.catcompany.desktop-smoke', productName: 'CatsCoSmoke',
+      directories: { output: path.join(scratch, version) },
+      extraMetadata: { name: 'catsco-desktop-smoke', version, main: 'electron/desktop-smoke-bootstrap.cjs' },
+      files: [...base.files, { from: 'scripts/desktop-smoke-bootstrap.cjs', to: 'electron/desktop-smoke-bootstrap.cjs' }],
+      extraResources: [{ from: configFile, to: 'desktop-smoke.json' }],
+      nsis: { ...base.nsis, createDesktopShortcut: false, createStartMenuShortcut: false, runAfterFinish: false },
+      mac: { ...base.mac, identity: null },
+      afterSign: undefined,
+    },
+  });
+}
+async function waitForReport(version) {
+  const filename = path.join(reports, `${version}.json`);
+  for (let i = 0; i < 2400; i++) {
+    if (fs.existsSync(filename)) {
+      const report = JSON.parse(fs.readFileSync(filename));
+      assert.equal(report.ok, true, JSON.stringify(report));
+      return report;
+    }
+    await new Promise(resolve => setTimeout(resolve, 100));
+  }
+  throw new Error(`No successful startup report for ${version}`);
+}
+try {
+  if (win) {
+    // Both installers are independent builds of the PR, not a blockmap planner.
+    const oldInstaller = path.join(scratch, oldVersion, `CatsCoSmoke-${oldVersion}-win.exe`);
+    smokeConfig.oldInstaller = oldInstaller;
+    const oldFiles = await packageVersion(oldVersion);
+    const nextFiles = await packageVersion(newVersion);
+    for (const file of [...oldFiles, ...nextFiles]) if (fs.existsSync(file)) served.set(path.basename(file), file);
+    for (const version of [oldVersion, newVersion]) {
+      const dir = path.join(scratch, version);
+      for (const name of fs.readdirSync(dir)) if (/\.blockmap$|^latest\.yml$/.test(name)) served.set(name, path.join(dir, name));
+    }
+    assert.ok(served.has('latest.yml'));
+    const installer = nextFiles.find(file => file.endsWith('.exe'));
+    const installDir = path.join(scratch, 'installed');
+    await run(oldInstaller, ['/S', `/D=${installDir}`]);
+    const appExe = path.join(installDir, 'CatsCoSmoke.exe');
+    assert.ok(fs.existsSync(appExe), 'Old NSIS installation completed');
+    const log = fs.openSync(path.join(reports, 'app.log'), 'w');
+    child = spawn(appExe, [], { cwd: installDir, stdio: ['ignore', log, log] });
+    await waitForReport(oldVersion);
+    await waitForReport(newVersion);
+    const total = fs.statSync(installer).size;
+    assert.equal(fullBytes, 0, 'Must not silently fall back to a full EXE download');
+    assert.ok(rangeBytes > 0 && rangeBytes < total * 0.5, `Delta ${rangeBytes}/${total} must be below 50%`);
+    const result = { oldVersion, newVersion, fullInstallerBytes: total, downloadedExeBytes: rangeBytes, ratio: rangeBytes / total, fullBytes, requests };
+    fs.writeFileSync(path.join(reports, 'update-result.json'), JSON.stringify(result, null, 2));
+    console.log(JSON.stringify(result));
+  } else {
+    const files = await packageVersion(newVersion);
+    let executable;
+    if (mac) {
+      const zip = files.find(file => file.endsWith('.zip'));
+      const extracted = path.join(scratch, 'extracted');
+      await run('ditto', ['-x', '-k', zip, extracted]);
+      executable = path.join(extracted, 'CatsCoSmoke.app', 'Contents', 'MacOS', 'CatsCoSmoke');
+    } else {
+      const appImage = files.find(file => file.endsWith('.AppImage'));
+      await run(appImage, ['--appimage-extract'], { cwd: scratch });
+      executable = path.join(scratch, 'squashfs-root', 'AppRun');
+    }
+    const log = fs.openSync(path.join(reports, 'app.log'), 'w');
+    child = spawn(executable, ['--no-sandbox'], { cwd: scratch, stdio: ['ignore', log, log] });
+    await waitForReport(newVersion);
+    console.log(fs.readFileSync(path.join(reports, `${newVersion}.json`), 'utf8'));
+  }
+} finally {
+  server.close();
+  if (child && child.exitCode === null) child.kill();
+  // Runner disposal removes installation/cache; reports survive via artifact upload.
+}

--- a/scripts/desktop-package-smoke.mjs
+++ b/scripts/desktop-package-smoke.mjs
@@ -72,7 +72,8 @@ async function packageVersion(version) {
   };
   // Pass one config file: programmatic overrides concatenate extraFiles with
   // the auto-discovered config and attempt to copy runtime symlinks twice.
-  const builderConfig = path.join(scratch, 'electron-builder-smoke.cjs');
+  // CommonJS configs are cached by filename inside electron-builder.
+  const builderConfig = path.join(scratch, `electron-builder-smoke-${version}.cjs`);
   fs.writeFileSync(builderConfig, `module.exports = { ...require(${JSON.stringify(path.join(root, 'electron-builder.config.cjs'))}), ...${JSON.stringify(overrides)} };`);
   return build({
     targets: platform.createTarget(win ? ['nsis'] : mac ? ['dmg', 'zip'] : ['AppImage', 'deb'], arch),

--- a/scripts/desktop-smoke-bootstrap.cjs
+++ b/scripts/desktop-smoke-bootstrap.cjs
@@ -1,0 +1,93 @@
+// Included only by desktop-package-smoke.mjs, never by the release config.
+const fs = require('node:fs');
+const path = require('node:path');
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+const { app, BrowserWindow } = require('electron');
+const config = JSON.parse(fs.readFileSync(path.join(process.resourcesPath, 'desktop-smoke.json'), 'utf8'));
+const report = value => fs.writeFileSync(path.join(config.reportDir, `${app.getVersion()}.json`), JSON.stringify(value, null, 2));
+const nativeLoads = [];
+const dlopen = process.dlopen;
+process.dlopen = function (module, filename, ...args) {
+  nativeLoads.push(filename);
+  assert.doesNotMatch(filename, /[\\/]deasync[\\/]/);
+  return dlopen.call(this, module, filename, ...args);
+};
+process.env.XIAOBA_ELECTRON_USER_DATA_DIR = path.join(config.reportDir, 'user-data');
+process.env.XIAOBA_DASHBOARD_PORT = String(config.dashboardPort);
+process.env.XIAOBA_DISABLE_GPU = '1';
+process.env.DASHBOARD_API_KEY = '';
+process.env.XIAOBA_APP_ROOT = path.dirname(__dirname);
+for (const key of ['XIAOBA_RUNTIME_ROOT', 'CATSCO_LOCAL_CONFIG_PATH', 'XIAOBA_SKILLS_DIR', 'XIAOBA_NODE_MODULES', 'NODE_PATH']) delete process.env[key];
+const deadline = setTimeout(() => fail(new Error('Packaged startup/update timed out')), 180_000);
+function fail(error) {
+  report({ ok: false, version: app.getVersion(), error: error.stack || String(error), nativeLoads });
+  app.exit(1);
+}
+async function probe(appRoot) {
+  const assert = require('node:assert/strict');
+  const fs = require('node:fs');
+  const path = require('node:path');
+  const req = require('node:module').createRequire(path.join(appRoot, 'package.json'));
+  const sharp = req('sharp');
+  const png = await sharp({ create: { width: 16, height: 16, channels: 4, background: '#ffffff' } }).resize(8, 8).png().toBuffer();
+  assert.equal((await sharp(png).metadata()).width, 8);
+  const canvas = req('@napi-rs/canvas').createCanvas(16, 16);
+  canvas.getContext('2d').fillRect(0, 0, 8, 8);
+  assert.ok(canvas.toBuffer('image/png').length > 0);
+  for (const name of ['deasync', 'canvas', 'path2d']) {
+    assert.equal(fs.existsSync(path.join(appRoot, 'node_modules', name)), false, name);
+    assert.throws(() => req(name), { code: 'MODULE_NOT_FOUND' });
+  }
+  return { node: process.versions.node, electron: process.versions.electron || null, sharp: true, canvas: true, excluded: true };
+}
+require('./main.js');
+app.whenReady().then(async () => {
+  let window;
+  for (let i = 0; i < 600; i++) {
+    window = BrowserWindow.getAllWindows()[0];
+    if (window && !window.webContents.isLoading() && window.webContents.getURL().startsWith('http://127.0.0.1:')) break;
+    await new Promise(resolve => setTimeout(resolve, 100));
+  }
+  assert.ok(window, 'Dashboard window created');
+  const renderer = await window.webContents.executeJavaScript('({ text: document.body.innerText.length, bridge: typeof window.catscoDesktop, require: typeof require })');
+  assert.ok(renderer.text > 20, 'Dashboard rendered');
+  assert.equal(renderer.bridge, 'object');
+  assert.equal(renderer.require, 'undefined', 'Renderer remains isolated');
+  const appRoot = path.dirname(__dirname);
+  const electronNative = await probe(appRoot);
+  const runtime = path.resolve(process.resourcesPath, '..', 'runtime');
+  const bundledNode = path.join(runtime, 'node', process.platform === 'win32' ? 'node.exe' : 'bin/node');
+  const child = spawnSync(bundledNode, ['-e', `(${probe.toString()})(${JSON.stringify(appRoot)}).then(x=>console.log(JSON.stringify(x))).catch(e=>{console.error(e);process.exit(1)})`], {
+    cwd: appRoot, encoding: 'utf8', env: { ...process.env, NODE_PATH: path.join(appRoot, 'node_modules') }, timeout: 30_000,
+  });
+  assert.equal(child.status, 0, child.stderr);
+  const nodeNative = JSON.parse(child.stdout.trim());
+  assert.equal(fs.existsSync(path.join(process.resourcesPath, 'runtime', 'node_modules')), false, 'No duplicate dependencies');
+  const result = { ok: true, version: app.getVersion(), renderer, electronNative, nodeNative, nativeLoads };
+  if (config.update && app.getVersion() === config.oldVersion) {
+    const { autoUpdater } = require('electron-updater');
+    const log = path.join(config.reportDir, 'differential.log');
+    autoUpdater.logger = Object.fromEntries(['info', 'warn', 'error', 'debug'].map(level => [level, (...args) => fs.appendFileSync(log, `${level}: ${args.join(' ')}\n`)]));
+    // Emulate the old installer cached by the preceding install/download.
+    // Do not seed its blockmap: the real updater must fetch both blockmaps.
+    const helper = await autoUpdater.getOrCreateDownloadHelper();
+    fs.mkdirSync(helper.cacheDir, { recursive: true });
+    fs.copyFileSync(config.oldInstaller, path.join(helper.cacheDir, 'installer.exe'));
+    await autoUpdater.checkForUpdates();
+    const files = await autoUpdater.downloadUpdate();
+    const text = fs.readFileSync(log, 'utf8');
+    assert.match(text, /Differential download/i);
+    assert.doesNotMatch(text, /fallback to full download/i);
+    assert.ok(files.length > 0);
+    report({ ...result, downloaded: true });
+    clearTimeout(deadline);
+    autoUpdater.quitAndInstall(true, true);
+  } else {
+    report(result);
+    clearTimeout(deadline);
+    app.quit();
+  }
+}).catch(fail);
+process.on('uncaughtException', fail);
+process.on('unhandledRejection', fail);

--- a/src/tools/read-tool.ts
+++ b/src/tools/read-tool.ts
@@ -51,7 +51,7 @@ interface PdfParseResult {
   info?: Record<string, unknown>;
 }
 
-type PdfParse = (dataBuffer: Buffer, options?: PdfParseOptions) => Promise<PdfParseResult>;
+type PdfParse = (dataBuffer: Uint8Array, options?: PdfParseOptions) => Promise<PdfParseResult>;
 const pdfParse: PdfParse = require('pdf-parse');
 
 interface TextReadOptions {
@@ -557,7 +557,10 @@ export class ReadTool implements Tool {
   }
 
   private async extractPdfText(absolutePath: string, selection: PdfPageSelection): Promise<PdfParseResult> {
-    const data = fs.readFileSync(absolutePath);
+    // Legacy PDF.js creates substreams from .buffer without accounting for a
+    // Buffer's byteOffset. Its fake-worker clone can also allocate from the
+    // Buffer pool. A plain owned Uint8Array keeps both paths zero-offset.
+    const data = Uint8Array.from(fs.readFileSync(absolutePath));
     const selectedPages = selection.selectedPages;
     const options: PdfParseOptions = {
       max: selection.maxPageToRender,

--- a/tests/electron-package-config.test.ts
+++ b/tests/electron-package-config.test.ts
@@ -1,6 +1,7 @@
 import { execFileSync } from 'node:child_process';
 import * as assert from 'node:assert';
 import * as fs from 'node:fs';
+import * as os from 'node:os';
 import * as path from 'node:path';
 import { test } from 'node:test';
 
@@ -18,6 +19,12 @@ const packageJson = JSON.parse(
 };
 
 const electronMain = fs.readFileSync(path.join(root, 'electron', 'main.js'), 'utf8');
+const builderConfig = require('../electron-builder.config.cjs') as {
+  afterPack?: (context: {
+    appOutDir: string;
+    packager: { getResourcesDir: (appOutDir: string) => string };
+  }) => void;
+};
 
 test('TOS updater uses single-range requests for differential downloads', () => {
   const configPath = path.join(root, 'electron-builder.config.cjs');
@@ -45,6 +52,32 @@ test('Windows packages retain differential metadata and one production dependenc
   );
   assert.match(electronMain, /path\.join\(getAppRoot\(\), 'node_modules'\)/);
   assert.doesNotMatch(electronMain, /path\.join\(process\.resourcesPath, 'node_modules'\)/);
+});
+
+test('desktop packaging removes only the worker-only deasync dependency', () => {
+  assert.equal(typeof builderConfig.afterPack, 'function');
+  const appOutDir = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-package-config-'));
+  const resourcesDir = path.join(appOutDir, 'platform-resources');
+  const nodeModules = path.join(resourcesDir, 'app', 'node_modules');
+  const deasyncPath = path.join(nodeModules, 'deasync');
+  const sharpPath = path.join(nodeModules, 'sharp');
+
+  try {
+    fs.mkdirSync(deasyncPath, { recursive: true });
+    fs.mkdirSync(sharpPath, { recursive: true });
+    fs.writeFileSync(path.join(deasyncPath, 'package.json'), '{}');
+    fs.writeFileSync(path.join(sharpPath, 'package.json'), '{}');
+
+    builderConfig.afterPack?.({
+      appOutDir,
+      packager: { getResourcesDir: () => resourcesDir },
+    });
+
+    assert.equal(fs.existsSync(deasyncPath), false);
+    assert.equal(fs.existsSync(path.join(sharpPath, 'package.json')), true);
+  } finally {
+    fs.rmSync(appOutDir, { recursive: true, force: true });
+  }
 });
 
 test('desktop package omits generated TypeScript metadata', () => {

--- a/tests/electron-package-config.test.ts
+++ b/tests/electron-package-config.test.ts
@@ -1,0 +1,55 @@
+import { execFileSync } from 'node:child_process';
+import * as assert from 'node:assert';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { test } from 'node:test';
+
+const root = process.cwd();
+const packageJson = JSON.parse(
+  fs.readFileSync(path.join(root, 'package.json'), 'utf8'),
+) as {
+  dependencies?: Record<string, string>;
+  build?: {
+    files?: string[];
+    extraResources?: Array<{ from?: string }>;
+    npmRebuild?: boolean;
+    nsis?: { differentialPackage?: boolean };
+  };
+};
+
+const electronMain = fs.readFileSync(path.join(root, 'electron', 'main.js'), 'utf8');
+
+test('TOS updater uses single-range requests for differential downloads', () => {
+  const configPath = path.join(root, 'electron-builder.config.cjs');
+  const script = `process.stdout.write(JSON.stringify(require(${JSON.stringify(configPath)}).publish))`;
+  const output = execFileSync(process.execPath, ['-e', script], {
+    cwd: root,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      XIAOBA_UPDATE_BASE_URL: 'https://github-release.tos-cn-guangzhou.volces.com/update',
+    },
+  });
+  const publish = JSON.parse(output) as Array<Record<string, unknown>>;
+
+  assert.equal(publish[0]?.provider, 'generic');
+  assert.equal(publish[0]?.useMultipleRangeRequest, false);
+});
+
+test('Windows packages retain differential metadata and one production dependency tree', () => {
+  assert.equal(packageJson.build?.nsis?.differentialPackage, true);
+  assert.equal(packageJson.build?.npmRebuild, false);
+  assert.equal(
+    packageJson.build?.extraResources?.some((resource) => resource.from === 'node_modules') || false,
+    false,
+  );
+  assert.match(electronMain, /path\.join\(getAppRoot\(\), 'node_modules'\)/);
+  assert.doesNotMatch(electronMain, /path\.join\(process\.resourcesPath, 'node_modules'\)/);
+});
+
+test('desktop package omits generated TypeScript metadata', () => {
+  for (const pattern of ['!dist/**/*.d.ts', '!dist/**/*.d.ts.map', '!dist/**/*.js.map']) {
+    assert.ok(packageJson.build?.files?.includes(pattern), `missing package exclusion: ${pattern}`);
+  }
+  assert.ok(packageJson.dependencies?.['electron-updater']);
+});

--- a/tests/tool-result-read-tool.test.ts
+++ b/tests/tool-result-read-tool.test.ts
@@ -329,9 +329,26 @@ describe('ReadTool - ToolExecutionResult', () => {
     assert.ok(result.message.includes('文件不存在'));
   });
 
-  test('PDF 文件会提取正文文本', async () => {
+  test('PDF 文件会提取正文文本，即使文件 Buffer 存在非零偏移', async t => {
     const filePath = path.join(testRoot, 'fixture.pdf');
     writeTextPdfFixture(filePath);
+    // Legacy PDF.js clones Buffers with their constructor. A larger pool makes
+    // that clone a slice too, deterministically reproducing the full-suite bug.
+    const previousPoolSize = Buffer.poolSize;
+    Buffer.poolSize = 65536;
+    Buffer.allocUnsafe(32767);
+    t.after(() => { Buffer.poolSize = previousPoolSize; });
+    const originalRead = fs.readFileSync;
+    let offsetBufferRead = false;
+    t.mock.method(require('fs'), 'readFileSync', (file: any, ...args: any[]) => {
+      const data = (originalRead as any)(file, ...args);
+      if (String(file) !== filePath || !Buffer.isBuffer(data)) return data;
+      const allocation = Buffer.allocUnsafeSlow(data.length + 128);
+      allocation.fill(0);
+      data.copy(allocation, 128);
+      offsetBufferRead = true;
+      return allocation.subarray(128);
+    });
 
     const result = await tool.execute({ file_path: filePath, pages: '1' }, context);
 
@@ -343,6 +360,7 @@ describe('ReadTool - ToolExecutionResult', () => {
     assert.ok(content.includes('文本内容:'));
     assert.ok(content.includes('Trace-based'));
     assert.ok(!content.includes('不再做 PDF 全文解析'));
+    assert.equal(offsetBufferRead, true);
   });
 
   test('PDF 默认只读取前若干页并提示继续读取', async () => {

--- a/tests/tool-result-read-tool.test.ts
+++ b/tests/tool-result-read-tool.test.ts
@@ -338,7 +338,7 @@ describe('ReadTool - ToolExecutionResult', () => {
     assert.strictEqual(result.ok, true);
     const content = result.content as string;
     assert.ok(content.includes('类型: PDF'));
-    assert.ok(content.includes('总页数:'));
+    assert.ok(content.includes('总页数:'), content);
     assert.ok(content.includes('已解析页: 1'));
     assert.ok(content.includes('文本内容:'));
     assert.ok(content.includes('Trace-based'));


### PR DESCRIPTION
Desktop installs contained a duplicate production dependency tree and unnecessary source metadata. TOS also answers multi-range requests with the full object, defeating the updater's differential path.

This change keeps one production node_modules tree, excludes desktop-unused deasync and source maps/declarations, retains NSIS differential blockmaps, and configures the TOS Generic provider for single-range requests. Native N-API packages are preserved without an Electron rebuild. A full-suite PDF failure uncovered during review is also fixed: legacy PDF.js mishandles pooled Buffer offsets, so PDF input now uses an owned Uint8Array with a deterministic regression test.

Validation:
- Windows full runtime suite on the combined branch including #454: 1746 passed, 0 failed, 17 platform-specific skips. The Worker manifest mismatch test executes with real jq; the PDF regression was reproduced before the fix and passes after it. Latest-head CI also passed the combined TypeScript build.
- [Latest-head CI](https://github.com/buildsense-ai/XiaoBa-CLI/actions/runs/34193733448) passed. Legacy cross-repo smoke/e2e scripts are absent and skipped; the Skills paired contract job is the actual cross-repo validation.
- [Four-platform packaged acceptance](https://github.com/buildsense-ai/XiaoBa-CLI/actions/runs/34193733414) exercises the final ZIP/AppImage/NSIS payload, the rendered Dashboard, sharp resize and @napi-rs/canvas PNG output in both Electron and bundled Node, and exclusion of deasync/canvas/path2d. All four platform acceptance jobs passed.
- Windows acceptance builds two isolated unsigned test versions, installs the old NSIS package, runs real electron-updater differential download, rejects full fallback, checks actual EXE bytes below 50%, invokes the installer, and requires the restarted new version to render successfully. Both blockmaps come from HTTP; only the preceding installer cache is seeded. Measured result: 630859 EXE bytes versus a 274242361-byte full installer (0.23%); zero full EXE responses; 1153429 total HTTP response bytes including both blockmaps and metadata. Installation/restart completed and version 0.0.2 rendered successfully. These fixtures do not measure first-upgrade savings from the public 1.5.5 release or replace signed-release acceptance.

Earlier Windows measurements: installer 302342748 -> 271467970 bytes; about 8010 fewer installed files; 7-Zip extraction 56.6s -> 40.9s. Extraction is not an NSIS end-to-end installation time guarantee. The earlier 84.82 MiB estimate was a differential planner result, not measured network traffic.

No formal desktop release is published by this PR. Release signing/notarization stays in the existing tag-driven workflow.
