### PR TITLE
fix(catscompany): retry transient cloud model activation failures

### DIFF
--- a/src/bot-definition/ack-retry.ts
+++ b/src/bot-definition/ack-retry.ts
@@ -1,0 +1,35 @@
+import type { CloudBotModelSelection } from './cloud-client';
+
+export class CloudBotModelAckRetry {
+  private pending?: { selection: CloudBotModelSelection; error: string; attempts: number };
+  constructor(private readonly options: {
+    isActive(): boolean;
+    send(selection: CloudBotModelSelection, error: string): Promise<void>;
+    onError?(error: unknown, selection: CloudBotModelSelection): void;
+  }) {}
+
+  schedule(selection: CloudBotModelSelection, error: string): void {
+    if (!this.options.isActive() || (this.pending && this.pending.selection.revision > selection.revision)) return;
+    this.pending = { selection, error, attempts: 0 };
+  }
+
+  clear(selection: CloudBotModelSelection): void {
+    if (this.pending?.selection.revision === selection.revision) this.pending = undefined;
+  }
+
+  observe(selection: CloudBotModelSelection | undefined): void {
+    if (!selection || (this.pending && selection.revision > this.pending.selection.revision)) this.pending = undefined;
+  }
+
+  async retry(): Promise<void> {
+    const pending = this.pending;
+    if (!pending || !this.options.isActive()) return;
+    try {
+      await this.options.send(pending.selection, pending.error);
+      if (this.options.isActive() && this.pending === pending) this.pending = undefined;
+    } catch (error) {
+      if (!this.options.isActive() || this.pending !== pending) return;
+      if (++pending.attempts % 12 === 0) this.options.onError?.(error, pending.selection);
+    }
+  }
+}

--- a/src/bot-definition/activation.ts
+++ b/src/bot-definition/activation.ts
@@ -57,6 +57,8 @@ export interface PreparedBoundBotDefinition {
   appliedCloudRevision?: number;
   cloudSelection?: CloudBotModelSelection;
   cloudApplyError?: string;
+  /** The desired revision was not applied because a cloud dependency can be retried. */
+  cloudApplyRetryable?: boolean;
   skillSync?: PreparedBoundBotSkills;
 }
 
@@ -243,10 +245,13 @@ export async function prepareBoundBotDefinition(
         const cloudApplyError = targetRevisionApplied
           ? undefined
           : botSkillActivationDeferredError(skillSync?.sync?.errorCode);
+        const cloudApplyRetryable = !targetRevisionApplied
+          && botSkillActivationErrorIsRetryable(skillSync?.sync?.errorCode);
         definitionService.clearLegacyModelConfigurationWhenReady(definition);
         if (
           options.acknowledgeCloudSelection !== false
           && cloudSnapshot.configured
+          && !cloudApplyRetryable
         ) {
           try {
             await acknowledgeCloudBotDefinition(
@@ -270,6 +275,7 @@ export async function prepareBoundBotDefinition(
             ? { cloudRevision: appliedRevision, appliedCloudRevision: appliedRevision }
             : {}),
           ...(cloudApplyError ? { cloudApplyError } : {}),
+          ...(cloudApplyRetryable ? { cloudApplyRetryable: true } : {}),
           ...(skillSync ? { skillSync } : {}),
           cloudSelection: definition.model.kind === 'custom'
             ? {
@@ -611,6 +617,10 @@ function errorMessage(error: unknown): string {
 function botSkillActivationDeferredError(errorCode?: string): string {
   const code = String(errorCode || 'skill_revision_not_applied').trim();
   return `Bot Skill activation was deferred (${code}).`;
+}
+
+function botSkillActivationErrorIsRetryable(errorCode?: string): boolean {
+  return errorCode === 'cloud_unavailable' || errorCode === 'cloud_definition_unavailable';
 }
 
 function scheduleBundledDefaultPromptSnapshot(options: {

--- a/src/bot-definition/activation.ts
+++ b/src/bot-definition/activation.ts
@@ -42,6 +42,8 @@ export interface PrepareBoundBotDefinitionOptions extends BotDefinitionSyncServi
   cloudSelection?: CloudBotModelSelection;
   acknowledgeCloudSelection?: boolean;
   prepareSkills?: boolean;
+  /** Hot reload must not silently fall back to legacy/local startup after a failed cloud read. */
+  requireCloud?: boolean;
 }
 
 export interface PreparedBoundBotDefinition {
@@ -297,6 +299,7 @@ export async function prepareBoundBotDefinition(
         };
       }
     } catch (error) {
+      if (options.requireCloud) throw error;
       Logger.warning(`CatsCo BotDefinition cloud sync is temporarily unavailable; using local cache: ${errorMessage(error)}`);
     }
   }

--- a/src/bot-definition/runtime-reload.ts
+++ b/src/bot-definition/runtime-reload.ts
@@ -2,6 +2,10 @@ import type { CloudBotModelSelection } from './cloud-client';
 
 export interface CloudBotModelRuntimeReloadControllerOptions {
   initialRevision?: number;
+  initialPendingRevision?: number;
+  isActive?(): boolean;
+  now?(): number;
+  random?(): number;
   pullSelection(): Promise<CloudBotModelSelection | undefined>;
   isIdle(): boolean;
   applySelection(selection: CloudBotModelSelection): Promise<'applied' | 'deferred'>;
@@ -13,37 +17,51 @@ export class CloudBotModelRuntimeReloadController {
   private handledRevision: number;
   private pendingSelection?: CloudBotModelSelection;
   private polling = false;
+  private retryAt = 0;
+  private retryAttempt = 0;
 
   constructor(private readonly options: CloudBotModelRuntimeReloadControllerOptions) {
-    this.handledRevision = options.initialRevision ?? -1;
+    this.handledRevision = options.initialRevision
+      ?? (options.initialPendingRevision !== undefined ? options.initialPendingRevision - 1 : -1);
   }
 
   async pollOnce(): Promise<void> {
-    if (this.polling) return;
+    if (this.polling || this.options.isActive?.() === false) return;
     this.polling = true;
     let selection: CloudBotModelSelection | undefined;
     try {
       selection = await this.options.pullSelection();
+      if (this.options.isActive?.() === false) return;
       if (!selection) {
         this.pendingSelection = undefined;
+        this.retryAt = this.retryAttempt = 0;
         return;
       }
       if (selection.revision > this.handledRevision) {
         if (!this.pendingSelection || selection.revision >= this.pendingSelection.revision) {
+          if (selection.revision !== this.pendingSelection?.revision) this.retryAt = this.retryAttempt = 0;
           this.pendingSelection = selection;
         }
       }
       const pending = this.pendingSelection;
-      if (!pending || !this.options.isIdle()) return;
+      if (!pending || !this.options.isIdle() || (this.options.now?.() ?? Date.now()) < this.retryAt) return;
 
       try {
         const outcome = await this.options.applySelection(pending);
-        if (outcome === 'deferred') return;
+        if (this.options.isActive?.() === false) return;
+        if (outcome === 'deferred') {
+          const delay = Math.min(60_000, 5_000 * 2 ** Math.min(this.retryAttempt++, 4));
+          this.retryAt = (this.options.now?.() ?? Date.now())
+            + Math.min(60_000, delay * (1 + (this.options.random?.() ?? Math.random()) * 0.2));
+          return;
+        }
+        this.retryAt = this.retryAttempt = 0;
         this.handledRevision = Math.max(this.handledRevision, pending.revision);
         if (this.pendingSelection?.revision === pending.revision) {
           this.pendingSelection = undefined;
         }
       } catch (error) {
+        if (this.options.isActive?.() === false) return;
         this.handledRevision = Math.max(this.handledRevision, pending.revision);
         if (this.pendingSelection?.revision === pending.revision) {
           this.pendingSelection = undefined;

--- a/src/bot-definition/transient-error.ts
+++ b/src/bot-definition/transient-error.ts
@@ -1,0 +1,16 @@
+/** Classify transport failures by structured status/code, never provider prose. */
+export function isTransientCloudError(error: unknown): boolean {
+  let current = error;
+  const visited = new Set<unknown>();
+  while (current && typeof current === 'object' && !visited.has(current)) {
+    visited.add(current);
+    const value = current as { status?: number; code?: string; name?: string; message?: string; cause?: unknown };
+    if (value.status !== undefined) return [408, 425, 429, 500, 502, 503, 504].includes(value.status);
+    if (['AbortError', 'TimeoutError', 'RelayCredentialUnreachableError'].includes(value.name || '')) return true;
+    if (['ECONNRESET', 'ECONNREFUSED', 'ETIMEDOUT', 'ENETUNREACH', 'EAI_AGAIN', 'ENOTFOUND',
+      'UND_ERR_CONNECT_TIMEOUT', 'UND_ERR_HEADERS_TIMEOUT', 'UND_ERR_BODY_TIMEOUT', 'UND_ERR_SOCKET'].includes(value.code || '')) return true;
+    if (value.name === 'TypeError' && value.message === 'fetch failed') return true;
+    current = value.cause;
+  }
+  return false;
+}

--- a/src/bot-skills/sync-service.ts
+++ b/src/bot-skills/sync-service.ts
@@ -1,4 +1,5 @@
 import * as crypto from 'crypto';
+import { isTransientCloudError } from '../bot-definition/transient-error';
 import * as fs from 'fs';
 import * as path from 'path';
 import matter from 'gray-matter';
@@ -324,7 +325,7 @@ export class BotSkillSyncService {
         if (verifiedExisting) {
           return this.featureUnavailable({
             appliedRevision: base!.definitionRevision,
-            errorCode: 'cloud_unavailable',
+            errorCode: isTransientCloudError(error) ? 'cloud_unavailable' : 'cloud_request_rejected',
           });
         }
         throw new BotSkillCloudRestoreError(

--- a/src/commands/catscompany.ts
+++ b/src/commands/catscompany.ts
@@ -16,6 +16,8 @@ import {
   type CloudBotModelSelection,
 } from '../bot-definition/cloud-client';
 import { CloudBotModelRuntimeReloadController } from '../bot-definition/runtime-reload';
+import { isTransientCloudError } from '../bot-definition/transient-error';
+import { CloudBotModelAckRetry } from '../bot-definition/ack-retry';
 import { createBotDefinitionSyncService } from '../bot-definition/service';
 import { resolveRunnableCloudDefinition } from '../bot-definition/cloud-sync';
 import { getPromptReconcileCoordinator } from '../bot-definition/prompt-sync';
@@ -139,7 +141,6 @@ export async function catscompanyCommand(): Promise<void> {
   let ownerWatchTimer: NodeJS.Timeout | null = null;
   let cloudModelWatchTimer: NodeJS.Timeout | null = null;
   let cloudModelReloadPromise: Promise<void> | null = null;
-  let pendingCloudModelAck: PendingCloudModelAck | null = null;
   let skillActivationAckWorker: BotSkillActivationAckWorker | null = null;
   let shuttingDown = false;
 
@@ -186,6 +187,13 @@ export async function catscompanyCommand(): Promise<void> {
     await startRuntimeCommandSupport();
     const auth = createCatsCoLocalConfigService({ runtimeRoot }).getAuthState();
     const modelBotId = String(preparedBot?.botId || connectorConfig.botUid || '').trim();
+    const ackRetry = new CloudBotModelAckRetry({
+      isActive: () => !shuttingDown,
+      send: (selection, applyError) => acknowledgeCloudBotModelSelection({ botId: modelBotId, auth }, selection, applyError),
+      onError: (error, selection) => Logger.warning(
+        `CatsCo 云端模型 revision=${selection.revision} 状态回报仍在重试: ${errorMessage(error)}`,
+      ),
+    });
     if (activationAckWorkerEnabled) {
       const activationAckCredential = getUsableCatsCoRuntimeActivationAckCredential(connectorConfig);
       const connectorBotId = String(connectorConfig.botUid || '').trim();
@@ -223,11 +231,7 @@ export async function catscompanyCommand(): Promise<void> {
           initialApplyError,
         );
       } catch (error) {
-        pendingCloudModelAck = {
-          selection: preparedBot.cloudSelection,
-          applyError: initialApplyError,
-          attempts: 0,
-        };
+        ackRetry.schedule(preparedBot.cloudSelection, initialApplyError);
         Logger.warning(`CatsCo 启动模型状态回报失败，将自动重试: ${errorMessage(error)}`);
       }
     } else if (preparedBot?.cloudSelection) {
@@ -238,16 +242,15 @@ export async function catscompanyCommand(): Promise<void> {
     let lastCloudPollWarningAt = 0;
     const reloadController = new CloudBotModelRuntimeReloadController({
       initialRevision: preparedBot?.cloudApplyRetryable
-        ? undefined
+        ? preparedBot.appliedCloudRevision
         : preparedBot?.cloudSelection?.revision,
+      initialPendingRevision: preparedBot?.cloudApplyRetryable ? preparedBot.cloudSelection?.revision : undefined,
+      isActive: () => !shuttingDown,
       pullSelection: async () => {
         const selection = await pullCloudBotModelSelection({ botId: modelBotId, auth });
-        if (
-          pendingCloudModelAck
-          && (!selection || selection.revision > pendingCloudModelAck.selection.revision)
-        ) {
-          pendingCloudModelAck = null;
-        }
+        if (shuttingDown) return undefined;
+        ackRetry.observe(selection);
+        await ackRetry.retry();
         return selection;
       },
       isIdle: () => !shuttingDown && bot.isIdleForRuntimeReload(),
@@ -259,12 +262,10 @@ export async function catscompanyCommand(): Promise<void> {
         botId: modelBotId,
         canApply: () => !shuttingDown,
         scheduleAckRetry: (selection, applyError) => {
-          pendingCloudModelAck = { selection, applyError, attempts: 0 };
+          ackRetry.schedule(selection, applyError);
         },
         clearAckRetry: selection => {
-          if (pendingCloudModelAck?.selection.revision === selection.revision) {
-            pendingCloudModelAck = null;
-          }
+          ackRetry.clear(selection);
         },
         selection,
         auth,
@@ -283,23 +284,7 @@ export async function catscompanyCommand(): Promise<void> {
     });
     cloudModelWatchTimer = setInterval(() => {
       if (cloudModelReloadPromise) return;
-      const run = (async () => {
-        if (pendingCloudModelAck) {
-          const pending = pendingCloudModelAck;
-          try {
-            await acknowledgeCloudBotModelSelection({ botId: modelBotId, auth }, pending.selection, pending.applyError);
-            if (pendingCloudModelAck === pending) pendingCloudModelAck = null;
-          } catch (error) {
-            pending.attempts += 1;
-            if (pending.attempts % 12 === 0 && pendingCloudModelAck === pending) {
-              Logger.warning(
-                `CatsCo 云端模型 revision=${pending.selection.revision} 状态回报仍在重试: ${errorMessage(error)}`,
-              );
-            }
-          }
-        }
-        await reloadController.pollOnce();
-      })();
+      const run = reloadController.pollOnce();
       cloudModelReloadPromise = run;
       void run.finally(() => {
         if (cloudModelReloadPromise === run) cloudModelReloadPromise = null;
@@ -327,12 +312,6 @@ interface ApplyCloudModelRuntimeSelectionOptions {
   clearAckRetry(selection: CloudBotModelSelection): void;
   selection: CloudBotModelSelection;
   auth: CatsCoAuthSnapshot;
-}
-
-interface PendingCloudModelAck {
-  selection: CloudBotModelSelection;
-  applyError: string;
-  attempts: number;
 }
 
 function skillActivationAckWarning(code: BotSkillActivationAckWarningCode): string {
@@ -424,9 +403,15 @@ export async function applyCloudModelRuntimeSelection(
   let nextBot: CatsCompanyBot | undefined;
   try {
     await previousBot.destroy();
+    if (!options.canApply()) { restorePreviousModelFiles(); return 'deferred'; }
     nextBot = new CatsCompanyBot(options.connectorConfig);
     await nextBot.start();
     await nextBot.waitUntilReady();
+    if (!options.canApply()) {
+      await nextBot.destroy();
+      restorePreviousModelFiles();
+      return 'deferred';
+    }
     options.replaceBot(nextBot);
   } catch (error) {
     if (nextBot) {
@@ -501,6 +486,7 @@ async function applyCloudBotDefinitionSelection(
 
   let prepared: Awaited<ReturnType<typeof prepareBoundBotDefinition>>;
   let appliedSelection = options.selection;
+  if (!options.canApply()) return 'deferred';
   try {
     if (effectiveIncoming) definitionService.acceptCanonical(effectiveIncoming);
     prepared = await prepareBoundBotDefinition({
@@ -508,12 +494,19 @@ async function applyCloudBotDefinitionSelection(
       botId: options.botId,
       auth: options.auth,
       acknowledgeCloudSelection: false,
+      requireCloud: true,
     });
   } catch (error) {
     restorePreviousRuntime();
+    if (!options.canApply() || isTransientCloudError(error)) return 'deferred';
     const message = redactCloudBotModelError(error, options.selection);
     await acknowledgeCloudModelApply(options, message);
     throw new Error(message);
+  }
+
+  if (!options.canApply()) {
+    restorePreviousRuntime();
+    return 'deferred';
   }
 
   if (
@@ -549,9 +542,15 @@ async function applyCloudBotDefinitionSelection(
   let nextBot: CatsCompanyBot | undefined;
   try {
     await previousBot.destroy();
+    if (!options.canApply()) { restorePreviousRuntime(); return 'deferred'; }
     nextBot = new CatsCompanyBot(options.connectorConfig);
     await nextBot.start();
     await nextBot.waitUntilReady();
+    if (!options.canApply()) {
+      await nextBot.destroy();
+      restorePreviousRuntime();
+      return 'deferred';
+    }
     options.replaceBot(nextBot);
   } catch (error) {
     if (nextBot) {
@@ -620,13 +619,15 @@ async function acknowledgeCloudModelApply(
   applyError = '',
   selection: CloudBotModelSelection = options.selection,
 ): Promise<void> {
+  if (!options.canApply()) return;
   try {
     await acknowledgeCloudBotModelSelection({
       botId: options.botId,
       auth: options.auth,
     }, selection, applyError);
-    options.clearAckRetry(selection);
+    if (options.canApply()) options.clearAckRetry(selection);
   } catch (error) {
+    if (!options.canApply()) return;
     options.scheduleAckRetry(selection, applyError);
     Logger.warning(`CatsCo 云端模型应用状态回报失败: ${errorMessage(error)}`);
   }

--- a/src/commands/catscompany.ts
+++ b/src/commands/catscompany.ts
@@ -214,7 +214,7 @@ export async function catscompanyCommand(): Promise<void> {
         }
       }
     }
-    if (preparedBot?.cloudSelection) {
+    if (preparedBot?.cloudSelection && !preparedBot.cloudApplyRetryable) {
       const initialApplyError = preparedBot.cloudApplyError || '';
       try {
         await acknowledgeCloudBotModelSelection(
@@ -230,10 +230,16 @@ export async function catscompanyCommand(): Promise<void> {
         };
         Logger.warning(`CatsCo 启动模型状态回报失败，将自动重试: ${errorMessage(error)}`);
       }
+    } else if (preparedBot?.cloudSelection) {
+      Logger.warning(
+        `CatsCo BotDefinition revision=${preparedBot.cloudSelection.revision} preparation is temporarily unavailable; will retry automatically.`,
+      );
     }
     let lastCloudPollWarningAt = 0;
     const reloadController = new CloudBotModelRuntimeReloadController({
-      initialRevision: preparedBot?.cloudSelection?.revision,
+      initialRevision: preparedBot?.cloudApplyRetryable
+        ? undefined
+        : preparedBot?.cloudSelection?.revision,
       pullSelection: async () => {
         const selection = await pullCloudBotModelSelection({ botId: modelBotId, auth });
         if (
@@ -350,7 +356,7 @@ function skillActivationAckWarning(code: BotSkillActivationAckWarningCode): stri
   }
 }
 
-async function applyCloudModelRuntimeSelection(
+export async function applyCloudModelRuntimeSelection(
   options: ApplyCloudModelRuntimeSelectionOptions,
 ): Promise<'applied' | 'deferred'> {
   const botId = options.botId;
@@ -518,6 +524,12 @@ async function applyCloudBotDefinitionSelection(
   ) {
     const message = prepared?.cloudApplyError || 'Cloud BotDefinition runtime preparation did not complete.';
     restorePreviousRuntime();
+    if (prepared?.cloudApplyRetryable) {
+      Logger.warning(
+        `CatsCo BotDefinition revision=${options.selection.revision} preparation is temporarily unavailable; will retry automatically.`,
+      );
+      return 'deferred';
+    }
     await acknowledgeCloudModelApply(options, message);
     throw new Error(message);
   }

--- a/tests/bot-definition-activation.test.ts
+++ b/tests/bot-definition-activation.test.ts
@@ -435,6 +435,7 @@ describe('BotDefinition activation', () => {
     assert.equal(prepared?.appliedCloudRevision, undefined);
     assert.equal(prepared?.cloudRevision, undefined);
     assert.match(prepared?.cloudApplyError || '', /local_workspace_unverified/);
+    assert.equal(prepared?.cloudApplyRetryable, undefined);
     assert.equal(prepared?.skillSync?.sync?.applyStatus, 'deferred');
     assert.equal(prepared?.skillSync?.sync?.appliedRevision, undefined);
     assert.deepStrictEqual(ackBody, {
@@ -572,12 +573,10 @@ describe('BotDefinition activation', () => {
     assert.equal(prepared?.appliedCloudRevision, undefined);
     assert.equal(prepared?.cloudRevision, undefined);
     assert.match(prepared?.cloudApplyError || '', /cloud_unavailable/);
+    assert.equal(prepared?.cloudApplyRetryable, true);
     assert.equal(prepared?.skillSync?.sync?.applyStatus, 'deferred');
     assert.equal(prepared?.skillSync?.sync?.appliedRevision, 7);
-    assert.deepStrictEqual(ackBody, {
-      revision: 7,
-      error: 'Bot Skill activation was deferred (cloud_unavailable).',
-    });
+    assert.equal(ackBody, undefined, 'a retryable outage must leave the revision pending');
   });
 
   test('applies and acknowledges a cloud-selected model after its local runtime is ready', async () => {

--- a/tests/cloud-bot-model-ack-retry.test.ts
+++ b/tests/cloud-bot-model-ack-retry.test.ts
@@ -1,0 +1,57 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { CloudBotModelAckRetry } from '../src/bot-definition/ack-retry';
+import { CloudBotModelRuntimeReloadController } from '../src/bot-definition/runtime-reload';
+import { isTransientCloudError } from '../src/bot-definition/transient-error';
+
+test('a lost success ACK is retried without restarting the model', async () => {
+  let sends = 0;
+  let applies = 0;
+  const selection = { modelId: 'm', revision: 7 };
+  const ack = new CloudBotModelAckRetry({ isActive: () => true, send: async () => {
+    if (++sends === 1) throw new Error('lost ACK');
+  } });
+  const controller = new CloudBotModelRuntimeReloadController({
+    pullSelection: async () => { ack.observe(selection); await ack.retry(); return selection; },
+    isIdle: () => true,
+    applySelection: async () => { applies++; ack.schedule(selection, ''); await ack.retry(); return 'applied'; },
+  });
+  await controller.pollOnce(); await controller.pollOnce(); await controller.pollOnce();
+  assert.equal(applies, 1); assert.equal(sends, 2);
+});
+
+test('a newer revision or disabled cloud management drops an obsolete ACK', async () => {
+  const ack = new CloudBotModelAckRetry({ isActive: () => true, send: async () => assert.fail('stale ACK') });
+  ack.schedule({ modelId: 'old', revision: 7 }, '');
+  ack.observe({ modelId: 'new', revision: 8 }); await ack.retry();
+  ack.schedule({ modelId: 'new', revision: 8 }, '');
+  ack.observe(undefined); await ack.retry();
+});
+
+test('a late ACK cannot clear a newer pending ACK or reschedule after shutdown', async () => {
+  let active = true;
+  let finish!: () => void;
+  const revisions: number[] = [];
+  const ack = new CloudBotModelAckRetry({ isActive: () => active, send: async selection => {
+    revisions.push(selection.revision);
+    if (selection.revision === 7) await new Promise<void>(resolve => { finish = resolve; });
+  } });
+  ack.schedule({ modelId: 'm', revision: 7 }, '');
+  const pending = ack.retry();
+  ack.schedule({ modelId: 'm', revision: 8 }, '');
+  finish(); await pending; await ack.retry();
+  active = false;
+  ack.schedule({ modelId: 'm', revision: 9 }, ''); await ack.retry();
+  assert.deepEqual(revisions, [7, 8]);
+});
+
+test('transient cloud classification uses structured transport status and preserves auth failures', () => {
+  for (const status of [408, 425, 429, 500, 502, 503, 504]) assert.equal(isTransientCloudError({ status }), true);
+  for (const status of [400, 401, 403, 409, 422]) assert.equal(isTransientCloudError({ status, message: 'timeout 503' }), false);
+  for (const code of ['ECONNRESET', 'ETIMEDOUT', 'EAI_AGAIN', 'UND_ERR_CONNECT_TIMEOUT']) {
+    assert.equal(isTransientCloudError(new Error('wrapped', { cause: { code } })), true);
+  }
+  assert.equal(isTransientCloudError(new DOMException('deadline', 'TimeoutError')), true);
+  assert.equal(isTransientCloudError(new DOMException('aborted', 'AbortError')), true);
+  assert.equal(isTransientCloudError(new Error('unsupported model')), false);
+});

--- a/tests/cloud-bot-model-apply-retry.test.ts
+++ b/tests/cloud-bot-model-apply-retry.test.ts
@@ -12,7 +12,9 @@ import { createBotDefinitionSyncService } from '../src/bot-definition/service';
 import { BOT_DEFINITION_SCHEMA, type BotDefinition } from '../src/bot-definition/types';
 import { BotSkillBaseStore } from '../src/bot-skills/base-store';
 
-test('a cloud Skill recheck outage preserves the old connector and retries the same model revision', async t => {
+for (const failure of [502, 503, 504, 429, 'timeout', 'reset', 'shutdown'] as const) {
+for (const failureRead of [3, 4]) {
+test(`cloud recheck ${failure} at read ${failureRead} preserves the old connector`, async t => {
   const runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'model-apply-retry-'));
   t.after(() => fs.rmSync(runtimeRoot, { recursive: true, force: true }));
   const configService = createCatsCoLocalConfigService({ runtimeRoot });
@@ -42,6 +44,7 @@ test('a cloud Skill recheck outage preserves the old connector and retries the s
 
   let reads = 0;
   let failedOnce = false;
+  let active = true;
   const acks: unknown[] = [];
   t.mock.method(globalThis, 'fetch', async (input: string | URL | Request, init?: RequestInit) => {
     const url = new URL(String(input));
@@ -49,9 +52,12 @@ test('a cloud Skill recheck outage preserves the old connector and retries the s
     if (url.pathname === '/api/bot/definition' && method === 'GET') {
       reads += 1;
       // Poll, revision check, startup reconciliation, then Skill recheck.
-      if (reads === 4) {
+      if (reads === failureRead) {
         failedOnce = true;
-        return Response.json({ error: 'temporary outage' }, { status: 503 });
+        if (failure === 'shutdown') active = false;
+        else if (failure === 'timeout') throw new DOMException('Test timeout', 'TimeoutError');
+        else if (failure === 'reset') throw Object.assign(new TypeError('fetch failed'), { cause: { code: 'ECONNRESET' } });
+        else return Response.json({ error: 'temporary outage' }, { status: failure });
       }
       return Response.json({ configured: true, revision: 7, definition: desired });
     }
@@ -74,12 +80,14 @@ test('a cloud Skill recheck outage preserves the old connector and retries the s
   t.mock.method(CatsCompanyBot.prototype, 'waitUntilReady', async () => { ready += 1; });
   t.mock.method(CatsCompanyBot.prototype, 'isIdleForRuntimeReload', () => true);
   const errors: unknown[] = [];
+  let now = 0;
   const controller = new CloudBotModelRuntimeReloadController({
+    now: () => now, random: () => 0,
     initialRevision: 6,
     pullSelection: () => pullCloudBotModelSelection({ botId: '43', auth }),
     isIdle: () => true,
     applySelection: selection => applyCloudModelRuntimeSelection({
-      runtimeRoot, botId: '43', auth, selection, canApply: () => true,
+      runtimeRoot, botId: '43', auth, selection, canApply: () => active,
       connectorConfig: { serverUrl: 'wss://cats.example.test/v0/channels', apiKey: 'test-bot-key', botUid: '43' },
       currentBot: () => bot, replaceBot: next => { bot = next; },
       scheduleAckRetry: () => assert.fail('ACK should succeed'), clearAckRetry: () => {},
@@ -93,6 +101,14 @@ test('a cloud Skill recheck outage preserves the old connector and retries the s
   assert.equal(stopped, 0);
   assert.deepEqual(definitions.read('43')?.model, previous.model);
 
+  if (failure === 'shutdown') {
+    await controller.pollOnce();
+    assert.equal(started, 0);
+    assert.deepEqual(acks, []);
+    assert.deepEqual(errors, []);
+    return;
+  }
+  now = 5000;
   await controller.pollOnce();
   assert.notEqual(bot, oldBot);
   assert.equal(stopped, 1);
@@ -104,3 +120,6 @@ test('a cloud Skill recheck outage preserves the old connector and retries the s
   assert.equal(started, 1);
   assert.deepEqual(errors, []);
 });
+
+}
+}

--- a/tests/cloud-bot-model-apply-retry.test.ts
+++ b/tests/cloud-bot-model-apply-retry.test.ts
@@ -1,0 +1,106 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { test } from 'node:test';
+import { CatsCompanyBot } from '../src/catscompany';
+import { createCatsCoLocalConfigService } from '../src/catscompany/local-config';
+import { applyCloudModelRuntimeSelection } from '../src/commands/catscompany';
+import { pullCloudBotModelSelection } from '../src/bot-definition/cloud-client';
+import { CloudBotModelRuntimeReloadController } from '../src/bot-definition/runtime-reload';
+import { createBotDefinitionSyncService } from '../src/bot-definition/service';
+import { BOT_DEFINITION_SCHEMA, type BotDefinition } from '../src/bot-definition/types';
+import { BotSkillBaseStore } from '../src/bot-skills/base-store';
+
+test('a cloud Skill recheck outage preserves the old connector and retries the same model revision', async t => {
+  const runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'model-apply-retry-'));
+  t.after(() => fs.rmSync(runtimeRoot, { recursive: true, force: true }));
+  const configService = createCatsCoLocalConfigService({ runtimeRoot });
+  configService.save({
+    version: 1,
+    endpoints: { httpBaseUrl: 'https://cats.example.test', serverUrl: 'wss://cats.example.test/v0/channels' },
+    account: { token: 'test-owner-token', uid: '7' },
+    currentBot: { uid: '43', apiKey: 'test-bot-key', boundByUserUid: '7', bindingSource: 'test' },
+  });
+  const auth = configService.getAuthState();
+  const definitions = createBotDefinitionSyncService({ runtimeRoot });
+  const previous: BotDefinition = {
+    schema: BOT_DEFINITION_SCHEMA, botId: '43',
+    model: {
+      kind: 'custom', protocol: 'openai-responses', apiBase: 'https://models.example.test/v1',
+      apiKey: 'test-model-key', model: 'previous-model', contextWindowTokens: 128000,
+    },
+    prompt: { selected: 'custom', customSystemPrompt: 'Test prompt.' }, skills: [],
+  };
+  definitions.acceptCanonical(previous);
+  const desired = { ...previous, model: { ...previous.model, model: 'next-model' } };
+  fs.mkdirSync(path.join(runtimeRoot, 'skills'), { recursive: true });
+  new BotSkillBaseStore(runtimeRoot).write({
+    schema: 'xiaoba.bot-skill-sync-base.v2', botId: '43', definitionRevision: 6,
+    skills: [], updatedAt: new Date().toISOString(),
+  });
+
+  let reads = 0;
+  let failedOnce = false;
+  const acks: unknown[] = [];
+  t.mock.method(globalThis, 'fetch', async (input: string | URL | Request, init?: RequestInit) => {
+    const url = new URL(String(input));
+    const method = init?.method || 'GET';
+    if (url.pathname === '/api/bot/definition' && method === 'GET') {
+      reads += 1;
+      // Poll, revision check, startup reconciliation, then Skill recheck.
+      if (reads === 4) {
+        failedOnce = true;
+        return Response.json({ error: 'temporary outage' }, { status: 503 });
+      }
+      return Response.json({ configured: true, revision: 7, definition: desired });
+    }
+    if (url.pathname === '/api/bot/definition/ack' && method === 'POST') {
+      acks.push(JSON.parse(String(init?.body)));
+      return Response.json({ status: 'applied' });
+    }
+    if (url.pathname === '/api/bot/definition/default-prompt') return Response.json({ status: 'stored' });
+    throw new Error(`Unexpected test request: ${method} ${url.pathname}`);
+  });
+  let stopped = 0;
+  let started = 0;
+  let ready = 0;
+  const oldBot = { isIdleForRuntimeReload: () => true, destroy: async () => { stopped += 1; } } as CatsCompanyBot;
+  let bot = oldBot;
+  t.mock.method(CatsCompanyBot.prototype, 'start', async function (this: CatsCompanyBot) {
+    started += 1;
+    t.after(() => this.destroy());
+  });
+  t.mock.method(CatsCompanyBot.prototype, 'waitUntilReady', async () => { ready += 1; });
+  t.mock.method(CatsCompanyBot.prototype, 'isIdleForRuntimeReload', () => true);
+  const errors: unknown[] = [];
+  const controller = new CloudBotModelRuntimeReloadController({
+    initialRevision: 6,
+    pullSelection: () => pullCloudBotModelSelection({ botId: '43', auth }),
+    isIdle: () => true,
+    applySelection: selection => applyCloudModelRuntimeSelection({
+      runtimeRoot, botId: '43', auth, selection, canApply: () => true,
+      connectorConfig: { serverUrl: 'wss://cats.example.test/v0/channels', apiKey: 'test-bot-key', botUid: '43' },
+      currentBot: () => bot, replaceBot: next => { bot = next; },
+      scheduleAckRetry: () => assert.fail('ACK should succeed'), clearAckRetry: () => {},
+    }),
+    onError: error => errors.push(error),
+  });
+  await controller.pollOnce();
+  assert.equal(failedOnce, true);
+  assert.deepEqual(acks, []);
+  assert.equal(bot, oldBot);
+  assert.equal(stopped, 0);
+  assert.deepEqual(definitions.read('43')?.model, previous.model);
+
+  await controller.pollOnce();
+  assert.notEqual(bot, oldBot);
+  assert.equal(stopped, 1);
+  assert.equal(started, 1);
+  assert.equal(ready, 1);
+  assert.deepEqual(acks, [{ revision: 7 }]);
+  assert.deepEqual(definitions.read('43')?.model, desired.model);
+  await controller.pollOnce();
+  assert.equal(started, 1);
+  assert.deepEqual(errors, []);
+});

--- a/tests/cloud-bot-model-runtime-reload.test.ts
+++ b/tests/cloud-bot-model-runtime-reload.test.ts
@@ -4,6 +4,63 @@ import { CloudBotModelRuntimeReloadController } from '../src/bot-definition/runt
 import type { CloudBotModelSelection } from '../src/bot-definition/cloud-client';
 
 describe('CloudBotModelRuntimeReloadController', () => {
+  for (const revision of [undefined, 5, 7, 8]) {
+    test(`startup pending revision 7 only accepts same/newer cloud revision: ${revision}`, async () => {
+      const applied: number[] = [];
+      const controller = new CloudBotModelRuntimeReloadController({
+        initialPendingRevision: 7,
+        pullSelection: async () => revision === undefined ? undefined : { modelId: 'm', revision },
+        isIdle: () => true,
+        applySelection: async value => { applied.push(value.revision); return 'applied'; },
+      });
+      await controller.pollOnce();
+      await controller.pollOnce();
+      assert.deepEqual(applied, revision !== undefined && revision >= 7 ? [revision] : []);
+    });
+  }
+
+  test('an already applied startup revision is not prepared or restarted', async () => {
+    const controller = new CloudBotModelRuntimeReloadController({
+      initialRevision: 7, initialPendingRevision: 7,
+      pullSelection: async () => ({ modelId: 'm', revision: 7 }), isIdle: () => true,
+      applySelection: async () => assert.fail('must not restart'),
+    });
+    await controller.pollOnce();
+  });
+
+  test('persistent deferrals back off to 60 seconds and a newer revision bypasses the delay', async () => {
+    let now = 0;
+    let revision = 7;
+    const attempts: number[] = [];
+    const controller = new CloudBotModelRuntimeReloadController({
+      now: () => now, random: () => 0,
+      pullSelection: async () => ({ modelId: 'm', revision }), isIdle: () => true,
+      applySelection: async () => { attempts.push(now); return 'deferred'; },
+    });
+    for (now = 0; now <= 200000; now += 1000) await controller.pollOnce();
+    assert.deepEqual(attempts, [0, 5000, 15000, 35000, 75000, 135000, 195000]);
+    revision = 8;
+    await controller.pollOnce();
+    assert.equal(attempts.at(-1), 201000);
+  });
+
+  test('shutdown fences a late poll and concurrent polls do not overlap', async () => {
+    let active = true;
+    let finish!: (value: CloudBotModelSelection) => void;
+    let polls = 0;
+    const controller = new CloudBotModelRuntimeReloadController({
+      isActive: () => active, isIdle: () => true,
+      pullSelection: () => { polls++; return new Promise(resolve => { finish = resolve; }); },
+      applySelection: async () => assert.fail('must not apply after shutdown'),
+    });
+    const pending = controller.pollOnce();
+    await controller.pollOnce();
+    active = false;
+    finish({ modelId: 'm', revision: 7 });
+    await pending;
+    await controller.pollOnce();
+    assert.equal(polls, 1);
+  });
   test('applies each new revision once', async () => {
     let selection: CloudBotModelSelection | undefined = { modelId: 'minimax-m3', revision: 2 };
     const applied: number[] = [];
@@ -50,7 +107,9 @@ describe('CloudBotModelRuntimeReloadController', () => {
   test('retries the same revision after a transient apply deferral', async () => {
     const selection: CloudBotModelSelection = { modelId: 'glm-5.3-flash', revision: 4 };
     let attempts = 0;
+    let now = 0;
     const controller = new CloudBotModelRuntimeReloadController({
+      now: () => now, random: () => 0,
       pullSelection: async () => selection,
       isIdle: () => true,
       applySelection: async () => {
@@ -60,6 +119,7 @@ describe('CloudBotModelRuntimeReloadController', () => {
     });
 
     await controller.pollOnce();
+    now = 5000;
     await controller.pollOnce();
     await controller.pollOnce();
 

--- a/tests/cloud-bot-model-runtime-reload.test.ts
+++ b/tests/cloud-bot-model-runtime-reload.test.ts
@@ -47,6 +47,25 @@ describe('CloudBotModelRuntimeReloadController', () => {
     assert.deepStrictEqual(applied, [selection]);
   });
 
+  test('retries the same revision after a transient apply deferral', async () => {
+    const selection: CloudBotModelSelection = { modelId: 'glm-5.3-flash', revision: 4 };
+    let attempts = 0;
+    const controller = new CloudBotModelRuntimeReloadController({
+      pullSelection: async () => selection,
+      isIdle: () => true,
+      applySelection: async () => {
+        attempts += 1;
+        return attempts === 1 ? 'deferred' : 'applied';
+      },
+    });
+
+    await controller.pollOnce();
+    await controller.pollOnce();
+    await controller.pollOnce();
+
+    assert.equal(attempts, 2);
+  });
+
   test('does not loop a failed revision and allows a newer retry revision', async () => {
     let selection: CloudBotModelSelection = { modelId: 'gpt-5.6-luna', revision: 4 };
     const attempts: number[] = [];


### PR DESCRIPTION
A temporary cloud/Skill recheck failure after a model is selected on the web used to terminally fail and consume that revision. The runtime now keeps transient failures pending, preserves the old connector/model during preparation, and retries the same revision with bounded exponential backoff and jitter.

Startup rejects older revisions while permitting its pending revision to recover. Transport classification covers structured HTTP 502/503/504/429 and timeout/reset failures; auth/validation errors remain terminal. ACK retries observe the newest selection first, and shutdown fences prevent late callbacks from restarting or reporting an obsolete runtime. Successful application followed by an ACK outage does not restart the connector twice.

Validation at 6b293db:
- TypeScript build and 111 focused activation/reload/Skill/ACK tests passed, including real application-path transport and shutdown injection.
- [Latest-head CI](https://github.com/buildsense-ai/XiaoBa-CLI/actions/runs/34192248995) passed: Linux build/runtime, SkillHub mandatory regression, and CatsCompany/XiaoBa Skills paired contract tests. The legacy smoke/e2e job skips its absent scripts, so it is not an executed end-to-end acceptance result.
- Windows full runtime run with real jq: 1741 passed, 1 failed, 17 skipped. The remaining pre-existing PDF fixture test reports `bad XRef entry` in a full run and passes alone; #453 tracks that diagnostic. The Worker manifest assertion now executes and passes.

Independent of #453. CatsCompany already rejects stale revision ACKs and polls pending state; this fix needs no server/API change. Packaged user acceptance remains part of the next desktop release; this PR does not publish a version.
