### PR TITLE
test(desktop): check the actual duplicate dependency directory

### DIFF
--- a/scripts/desktop-smoke-bootstrap.cjs
+++ b/scripts/desktop-smoke-bootstrap.cjs
@@ -63,7 +63,7 @@ app.whenReady().then(async () => {
   });
   assert.equal(child.status, 0, child.stderr);
   const nodeNative = JSON.parse(child.stdout.trim());
-  assert.equal(fs.existsSync(path.join(process.resourcesPath, 'runtime', 'node_modules')), false, 'No duplicate dependencies');
+  assert.equal(fs.existsSync(path.join(process.resourcesPath, 'node_modules')), false, 'No duplicate dependencies');
   const result = { ok: true, version: app.getVersion(), renderer, electronNative, nodeNative, nativeLoads };
   if (config.update && app.getVersion() === config.oldVersion) {
     const { autoUpdater } = require('electron-updater');


### PR DESCRIPTION
The packaged-runtime smoke check looked for duplicate dependencies under `resources/runtime/node_modules`, while the extra dependency tree removed by #453 was actually under `resources/node_modules`. Point the assertion at the real location so a duplicate tree cannot silently pass this check.

Follow-up to #453 from an independent review. This changes only the CI smoke assertion; production packaging and update behavior remain unchanged.

Validation: `node --check scripts/desktop-smoke-bootstrap.cjs` and `git diff --check` passed. The reviewer rechecked the corrected path against the original `extraResources` configuration. The combined changes from #453/#454 also passed 52 targeted local regression tests before this one-line correction.

All checks passed on `4ea6880`: [CI](https://github.com/buildsense-ai/XiaoBa-CLI/actions/runs/34195563332) and [four-platform packaged runtime acceptance](https://github.com/buildsense-ai/XiaoBa-CLI/actions/runs/34195563296). Windows completed the controlled NSIS 0.0.1 → 0.0.2 differential download, installation, restart, Dashboard render and native module probes. The new assertion passed on Windows, Linux, macOS Intel and macOS Apple Silicon. This remains a controlled fixture test, not a measurement of real 1.5.5 migration or a production release acceptance run.
