### PR TITLE
feat: add isolated Foshan public worker image profile

### DIFF
--- a/.github/workflows/worker-image.yml
+++ b/.github/workflows/worker-image.yml
@@ -1,4 +1,5 @@
 name: Bake Tianyi Cloud Worker Image
+run-name: Worker image [${{ inputs.deployment_profile || 'private_nat' }}] ${{ github.ref_name }}
 
 on:
   push:
@@ -6,6 +7,12 @@ on:
       - "v*"
   workflow_dispatch:
     inputs:
+      deployment_profile:
+        description: Target worker resource pool
+        type: choice
+        required: true
+        default: private_nat
+        options: [private_nat, public_ip]
       bake_image:
         description: Bake a private worker image from the current main commit
         required: false
@@ -49,7 +56,6 @@ env:
   # previously baked image that passed the platform hardening gates. The
   # preparer still verifies the contract and falls back to a full upgrade when
   # the claim is stale.
-  WORKER_BASE_IMAGE_HARDENED: ${{ vars.CTYUN_WORKER_BASE_IMAGE_HARDENED || 'false' }}
 
 jobs:
   image:
@@ -99,6 +105,25 @@ jobs:
             echo "Manual image baking is restricted to main"
             exit 1
           fi
+
+      - name: Select worker deployment profile
+        id: deployment
+        shell: bash
+        env:
+          DEPLOYMENT_PROFILE: ${{ inputs.deployment_profile || 'private_nat' }}
+          CTYUN_PUBLIC_WORKER_PROFILE_JSON: ${{ vars.CTYUN_PUBLIC_WORKER_PROFILE_JSON }}
+          WORKER_REGION_ID: ${{ vars.CTYUN_WORKER_REGION_ID }}
+          WORKER_PROJECT_ID: ${{ vars.CTYUN_WORKER_PROJECT_ID }}
+          WORKER_IMAGE_PROJECT_ID: ${{ vars.CTYUN_IMAGE_PROJECT_ID || '0' }}
+          WORKER_AZ_NAME: ${{ vars.CTYUN_WORKER_AZ_NAME }}
+          WORKER_BASE_IMAGE_ID: ${{ vars.CTYUN_WORKER_BASE_IMAGE_ID }}
+          WORKER_FLAVOR_ID: ${{ vars.CTYUN_WORKER_FLAVOR_ID }}
+          WORKER_VPC_ID: ${{ vars.CTYUN_WORKER_VPC_ID }}
+          WORKER_SUBNET_ID: ${{ vars.CTYUN_WORKER_SUBNET_ID }}
+          WORKER_SECURITY_GROUP_ID: ${{ vars.CTYUN_WORKER_SECURITY_GROUP_ID }}
+          WORKER_PROTECTED_IMAGE_IDS: ${{ vars.CTYUN_WORKER_PROTECTED_IMAGE_IDS }}
+          WORKER_BASE_IMAGE_HARDENED: ${{ vars.CTYUN_WORKER_BASE_IMAGE_HARDENED || 'false' }}
+        run: node ops/ctyun-worker-image/deployment-profile.mjs
 
       - name: Install dependencies
         timeout-minutes: 20
@@ -353,11 +378,13 @@ jobs:
             [[ "$(jq '.workflow_runs | length' <<<"$response")" -lt 100 ]] && break
             page=$((page + 1))
           done
-          interrupted="$(jq -cs --arg current "$GITHUB_RUN_ID" '
+          interrupted="$(jq -cs --arg current "$GITHUB_RUN_ID" --arg profile "$WORKER_DEPLOYMENT_PROFILE" '
             add
             | [
               .[]
               | select((.id | tostring) != $current)
+              | select(if $profile == "public_ip" then (.display_title | startswith("Worker image [public_ip]"))
+                       else ((.display_title | startswith("Worker image [public_ip]")) | not) end)
               | select(
                   .conclusion == "failure" or
                   .conclusion == "cancelled" or
@@ -454,15 +481,6 @@ jobs:
           CTYUN_AK: ${{ secrets.CTYUN_AK }}
           CTYUN_SK: ${{ secrets.CTYUN_SK }}
           INTERRUPTED_RUNS_JSON: ${{ steps.prior_runs.outputs.runs }}
-          WORKER_REGION_ID: ${{ vars.CTYUN_WORKER_REGION_ID }}
-          WORKER_PROJECT_ID: ${{ vars.CTYUN_WORKER_PROJECT_ID }}
-          WORKER_IMAGE_PROJECT_ID: ${{ vars.CTYUN_IMAGE_PROJECT_ID || '0' }}
-          WORKER_AZ_NAME: ${{ vars.CTYUN_WORKER_AZ_NAME }}
-          WORKER_BASE_IMAGE_ID: ${{ vars.CTYUN_WORKER_BASE_IMAGE_ID }}
-          WORKER_FLAVOR_ID: ${{ vars.CTYUN_WORKER_FLAVOR_ID }}
-          WORKER_VPC_ID: ${{ vars.CTYUN_WORKER_VPC_ID }}
-          WORKER_SUBNET_ID: ${{ vars.CTYUN_WORKER_SUBNET_ID }}
-          WORKER_SECURITY_GROUP_ID: ${{ vars.CTYUN_WORKER_SECURITY_GROUP_ID }}
         run: |
           $runs = @($env:INTERRUPTED_RUNS_JSON | ConvertFrom-Json)
           if ([string]::IsNullOrWhiteSpace($env:WORKER_PROJECT_ID)) {
@@ -596,15 +614,6 @@ jobs:
         env:
           CTYUN_AK: ${{ secrets.CTYUN_AK }}
           CTYUN_SK: ${{ secrets.CTYUN_SK }}
-          WORKER_REGION_ID: ${{ vars.CTYUN_WORKER_REGION_ID }}
-          WORKER_PROJECT_ID: ${{ vars.CTYUN_WORKER_PROJECT_ID }}
-          WORKER_IMAGE_PROJECT_ID: ${{ vars.CTYUN_IMAGE_PROJECT_ID || '0' }}
-          WORKER_AZ_NAME: ${{ vars.CTYUN_WORKER_AZ_NAME }}
-          WORKER_BASE_IMAGE_ID: ${{ vars.CTYUN_WORKER_BASE_IMAGE_ID }}
-          WORKER_FLAVOR_ID: ${{ vars.CTYUN_WORKER_FLAVOR_ID }}
-          WORKER_VPC_ID: ${{ vars.CTYUN_WORKER_VPC_ID }}
-          WORKER_SUBNET_ID: ${{ vars.CTYUN_WORKER_SUBNET_ID }}
-          WORKER_SECURITY_GROUP_ID: ${{ vars.CTYUN_WORKER_SECURITY_GROUP_ID }}
         run: |
           $currentAttempt = [int]$env:GITHUB_RUN_ATTEMPT
           if ([string]::IsNullOrWhiteSpace($env:WORKER_PROJECT_ID)) {
@@ -667,15 +676,6 @@ jobs:
         env:
           CTYUN_AK: ${{ secrets.CTYUN_AK }}
           CTYUN_SK: ${{ secrets.CTYUN_SK }}
-          WORKER_REGION_ID: ${{ vars.CTYUN_WORKER_REGION_ID }}
-          WORKER_PROJECT_ID: ${{ vars.CTYUN_WORKER_PROJECT_ID }}
-          WORKER_IMAGE_PROJECT_ID: ${{ vars.CTYUN_IMAGE_PROJECT_ID || '0' }}
-          WORKER_AZ_NAME: ${{ vars.CTYUN_WORKER_AZ_NAME }}
-          WORKER_BASE_IMAGE_ID: ${{ vars.CTYUN_WORKER_BASE_IMAGE_ID }}
-          WORKER_FLAVOR_ID: ${{ vars.CTYUN_WORKER_FLAVOR_ID }}
-          WORKER_VPC_ID: ${{ vars.CTYUN_WORKER_VPC_ID }}
-          WORKER_SUBNET_ID: ${{ vars.CTYUN_WORKER_SUBNET_ID }}
-          WORKER_SECURITY_GROUP_ID: ${{ vars.CTYUN_WORKER_SECURITY_GROUP_ID }}
           WORKER_ARTIFACT_PATH: ${{ steps.artifact_meta.outputs.path }}
           WORKER_ARTIFACT_SHA256: ${{ steps.artifact_meta.outputs.sha256 }}
           WORKER_ARTIFACT_URL: ${{ steps.artifact_transport.outputs.url }}
@@ -707,6 +707,7 @@ jobs:
             -CleanupTimeoutMinutes 40 `
             -ApiTimeoutSeconds 90 `
             -BaseImageHardened:($env:WORKER_BASE_IMAGE_HARDENED -eq 'true') `
+            -PublicIP:($env:WORKER_PUBLIC_IP -eq 'true') `
             -RegionID $env:WORKER_REGION_ID `
             -BuilderProjectID $env:WORKER_PROJECT_ID `
             -ImageProjectID $env:WORKER_IMAGE_PROJECT_ID `
@@ -736,9 +737,6 @@ jobs:
         env:
           CTYUN_AK: ${{ secrets.CTYUN_AK }}
           CTYUN_SK: ${{ secrets.CTYUN_SK }}
-          WORKER_REGION_ID: ${{ vars.CTYUN_WORKER_REGION_ID }}
-          WORKER_IMAGE_PROJECT_ID: ${{ vars.CTYUN_IMAGE_PROJECT_ID || '0' }}
-          WORKER_PROTECTED_IMAGE_IDS: ${{ vars.CTYUN_WORKER_PROTECTED_IMAGE_IDS }}
         run: |
           ./ops/ctyun-worker-image/Manage-WorkerImages.ps1 `
             -Action Prune `
@@ -757,15 +755,6 @@ jobs:
         env:
           CTYUN_AK: ${{ secrets.CTYUN_AK }}
           CTYUN_SK: ${{ secrets.CTYUN_SK }}
-          WORKER_REGION_ID: ${{ vars.CTYUN_WORKER_REGION_ID }}
-          WORKER_PROJECT_ID: ${{ vars.CTYUN_WORKER_PROJECT_ID }}
-          WORKER_IMAGE_PROJECT_ID: ${{ vars.CTYUN_IMAGE_PROJECT_ID || '0' }}
-          WORKER_AZ_NAME: ${{ vars.CTYUN_WORKER_AZ_NAME }}
-          WORKER_BASE_IMAGE_ID: ${{ vars.CTYUN_WORKER_BASE_IMAGE_ID }}
-          WORKER_FLAVOR_ID: ${{ vars.CTYUN_WORKER_FLAVOR_ID }}
-          WORKER_VPC_ID: ${{ vars.CTYUN_WORKER_VPC_ID }}
-          WORKER_SUBNET_ID: ${{ vars.CTYUN_WORKER_SUBNET_ID }}
-          WORKER_SECURITY_GROUP_ID: ${{ vars.CTYUN_WORKER_SECURITY_GROUP_ID }}
         run: |
           if ([string]::IsNullOrWhiteSpace($env:WORKER_PROJECT_ID)) {
             throw 'CTYUN_WORKER_PROJECT_ID is required for failed-bake cleanup'

--- a/ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1
+++ b/ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1
@@ -65,6 +65,7 @@ param(
     [ValidateRange(60, 1800)]
     [int]$BootstrapStaleSeconds = 180,
     [switch]$BaseImageHardened,
+    [switch]$PublicIP,
     [switch]$WaitForLateResources
 )
 
@@ -1539,7 +1540,7 @@ shutdown -h now
         throw "Generated builder userData exceeds Tianyi Cloud's 16384-character limit"
     }
 
-    $createResponse = Invoke-Ctyun @(
+    $createArgs = @(
         "ecs", "CreateEcsInstance",
         "--regionID", $RegionID,
         "--projectID", $BuilderProjectID,
@@ -1559,12 +1560,16 @@ shutdown -h now
         "--keyPairID", $script:KeyPairID,
         "--userData", $userData,
         "--onDemand", "true",
-        "--extIP", "0",
+        "--extIP", $(if ($PublicIP) { "1" } else { "0" }),
         "--monitorService", "false",
         "--securityProduct", "false",
         "--trustInstance", "false",
         "--labelList", "[{`"labelKey`":`"purpose`",`"labelValue`":`"catsco-image-builder`"},{`"labelKey`":`"commit`",`"labelValue`":`"$shortCommit`"}]"
     )
+    if ($PublicIP) {
+        $createArgs += @("--bandwidth", "10", "--ipVersion", "ipv4", "--lineType", "standalone", "--demandBillingType", "upflowc")
+    }
+    $createResponse = Invoke-Ctyun $createArgs
     $createReturnObject = Get-PropertyValue `
         -InputObject $createResponse `
         -Name "returnObj"

--- a/ops/ctyun-worker-image/PUBLIC_PROFILE.md
+++ b/ops/ctyun-worker-image/PUBLIC_PROFILE.md
@@ -1,0 +1,29 @@
+# 佛山 7 公网 Worker 镜像
+
+`worker-image.yml` 的手动输入 `deployment_profile` 可选 `private_nat` 或 `public_ip`。标签自动制镜和默认手动操作保持 `private_nat`。工作流仍只接受 `main` 和已验证的稳定版本标签。
+
+在 `release-prod` 环境设置非敏感变量 `CTYUN_PUBLIC_WORKER_PROFILE_JSON`，字段为：
+
+```json
+{
+  "CTYUN_WORKER_REGION_ID": "200000004421",
+  "CTYUN_WORKER_PROJECT_ID": "<builder-project-id>",
+  "CTYUN_IMAGE_PROJECT_ID": "<image-project-id>",
+  "CTYUN_WORKER_AZ_NAME": "cn-gd-fos7-1a-public-citycloud",
+  "CTYUN_WORKER_BASE_IMAGE_ID": "<Ubuntu-24.04-public-image-id>",
+  "CTYUN_WORKER_FLAVOR_ID": "<flavor-id>",
+  "CTYUN_WORKER_VPC_ID": "<vpc-id>",
+  "CTYUN_WORKER_SUBNET_ID": "<subnet-id>",
+  "CTYUN_WORKER_SECURITY_GROUP_ID": "<security-group-id>",
+  "CTYUN_WORKER_BASE_IMAGE_HARDENED": "false",
+  "CTYUN_WORKER_PROTECTED_IMAGE_IDS": ""
+}
+```
+
+第一轮使用干净的 Ubuntu 公共镜像，不能选择带历史工作身份的业务镜像。`BASE_IMAGE_HARDENED` 首轮为 false；首次制镜后，把已验收及回滚镜像加入该方案自己的保护名单。保护名单为空时仍拒绝清理旧镜像。
+
+公网制镜机显式申请公网 IPv4 和带宽，用于出网读取短期签名制品与状态地址；过程仍无须入站 SSH。镜像硬化关闭密码和交互式 SSH 认证，终结阶段移除制镜机身份，正式供给时由控制面为每台机器注入独立密钥。
+
+配置先验证再进行云操作，同一次运行的制镜、失败清理和镜像保留均使用相同区域/项目。历史运行按部署方案筛选，原 NAT 全局变量不被改写。仍共用受保护工作流的串行并发组，临时 TOS 对象按运行标识隔离并清理。
+
+本变更只有制镜和配置能力；工作流测试使用假云 API，不能替代首次佛山 7 制镜及实际用户部署验收。CatsCompany 的控制面配置格式见关联 PR，其 JSON 不包含此处的基础镜像和清理字段。

--- a/ops/ctyun-worker-image/deployment-profile.mjs
+++ b/ops/ctyun-worker-image/deployment-profile.mjs
@@ -1,0 +1,40 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import {pathToFileURL} from 'node:url';
+
+const fields = ['REGION_ID', 'PROJECT_ID', 'IMAGE_PROJECT_ID', 'AZ_NAME', 'BASE_IMAGE_ID',
+  'FLAVOR_ID', 'VPC_ID', 'SUBNET_ID', 'SECURITY_GROUP_ID', 'BASE_IMAGE_HARDENED', 'PROTECTED_IMAGE_IDS'];
+
+export function resolveDeploymentProfile(profile, env) {
+  if (!['private_nat', 'public_ip'].includes(profile)) throw new Error('Unknown worker deployment profile');
+  const result = Object.fromEntries(fields.map(key => ['WORKER_' + key, env['WORKER_' + key] || '']));
+  if (profile === 'public_ip') {
+    const raw = JSON.parse(env.CTYUN_PUBLIC_WORKER_PROFILE_JSON || '{}');
+    const allowed = new Map(fields.map(key => [key === 'IMAGE_PROJECT_ID' ? 'CTYUN_IMAGE_PROJECT_ID' : 'CTYUN_WORKER_' + key, 'WORKER_' + key]));
+    if (!raw || Array.isArray(raw) || typeof raw !== 'object') throw new Error('Invalid public worker profile');
+    for (const key of Object.keys(result)) result[key] = ''; // no cross-region fallback
+    for (const [key, value] of Object.entries(raw)) {
+      if (!allowed.has(key)) throw new Error('Unsupported public worker profile field: ' + key);
+      result[allowed.get(key)] = value;
+    }
+    if (result.WORKER_REGION_ID !== '200000004421') throw new Error('Public workers require Foshan 7');
+  }
+  for (const [key, value] of Object.entries(result)) {
+    if (typeof value !== 'string' || /[\r\n\0]/.test(value)) throw new Error('Invalid worker profile value: ' + key);
+  }
+  for (const key of fields.slice(0, 9)) {
+    if (!result['WORKER_' + key].trim()) throw new Error('Worker profile requires ' + key);
+  }
+  result.WORKER_BASE_IMAGE_HARDENED ||= 'false';
+  if (!['true', 'false'].includes(result.WORKER_BASE_IMAGE_HARDENED)) throw new Error('Invalid hardened-base flag');
+  result.WORKER_PUBLIC_IP = profile === 'public_ip' ? 'true' : 'false';
+  result.WORKER_DEPLOYMENT_PROFILE = profile;
+  return result;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
+  const values = resolveDeploymentProfile(process.env.DEPLOYMENT_PROFILE || 'private_nat', process.env);
+  if (!process.env.GITHUB_ENV) throw new Error('GITHUB_ENV is required');
+  fs.appendFileSync(process.env.GITHUB_ENV, Object.entries(values).map(([key, value]) => `${key}=${value}\n`).join(''));
+  console.log(`Validated ${values.WORKER_DEPLOYMENT_PROFILE} image deployment configuration`);
+}

--- a/ops/ctyun-worker-image/prepare-image.sh
+++ b/ops/ctyun-worker-image/prepare-image.sh
@@ -277,6 +277,21 @@ fi
 #    (e.g. TS1127 from a truncated lib.es2017.string.d.ts). Set it for both the
 #    service user and root so the first npm ci/install never needs manual setup.
 image_phase worker-install
+# Every worker receives its own provider key pair. Public SSH must never
+# inherit password authentication from a base image or cloud-init defaults.
+mkdir -p /etc/ssh/sshd_config.d /run/sshd
+cat >/etc/ssh/sshd_config.d/00-catsco-key-auth.conf <<'EOF'
+PubkeyAuthentication yes
+PasswordAuthentication no
+KbdInteractiveAuthentication no
+PermitRootLogin prohibit-password
+EOF
+chmod 0644 /etc/ssh/sshd_config.d/00-catsco-key-auth.conf
+sshd -t || die "SSH key authentication configuration invalid"
+SSH_EFFECTIVE="$(sshd -T)"
+for setting in 'pubkeyauthentication yes' 'passwordauthentication no' 'kbdinteractiveauthentication no'; do
+  grep -Fxq "$setting" <<<"$SSH_EFFECTIVE" || die "SSH key authentication setting overridden: $setting"
+done
 printf 'registry=https://registry.npmmirror.com\n' >/root/.npmrc
 chmod 0644 /root/.npmrc
 id catsco-agent >/dev/null 2>&1 || useradd \

--- a/tests/worker-deployment-profile.test.ts
+++ b/tests/worker-deployment-profile.test.ts
@@ -1,0 +1,30 @@
+import {test} from 'node:test';
+import assert from 'node:assert/strict';
+import {resolveDeploymentProfile} from '../ops/ctyun-worker-image/deployment-profile.mjs';
+
+const required=['REGION_ID','PROJECT_ID','IMAGE_PROJECT_ID','AZ_NAME','BASE_IMAGE_ID','FLAVOR_ID','VPC_ID','SUBNET_ID','SECURITY_GROUP_ID'];
+const nat=Object.fromEntries(required.map(key=>['WORKER_'+key,'nat-'+key]));
+const publicValues=Object.fromEntries(required.map(key=>[key==='IMAGE_PROJECT_ID'?'CTYUN_IMAGE_PROJECT_ID':'CTYUN_WORKER_'+key,'public-'+key]));
+publicValues.CTYUN_WORKER_REGION_ID='200000004421';
+
+test('public bake configuration is region scoped and never inherits NAT resources',()=>{
+  const env={...nat,WORKER_BASE_IMAGE_HARDENED:'true',WORKER_PROTECTED_IMAGE_IDS:'nat-protected',CTYUN_PUBLIC_WORKER_PROFILE_JSON:JSON.stringify(publicValues)};
+  const result=resolveDeploymentProfile('public_ip',env);
+  assert.equal(result.WORKER_REGION_ID,'200000004421');
+  assert.equal(result.WORKER_PUBLIC_IP,'true');
+  assert.equal(result.WORKER_BASE_IMAGE_HARDENED,'false');
+  assert.equal(result.WORKER_PROTECTED_IMAGE_IDS,'');
+  assert.equal(result.WORKER_VPC_ID,'public-VPC_ID');
+  assert.equal(env.WORKER_VPC_ID,'nat-VPC_ID');
+});
+test('incomplete, injected and wrong-region public profiles fail before cloud operations',()=>{
+  for(const raw of [{}, {...publicValues,CTYUN_WORKER_REGION_ID:'nat-region'}, {...publicValues,CTYUN_WORKER_VPC_ID:'vpc\nCTYUN_AK=fake'}, {...publicValues,CTYUN_AK:'fake'}]) {
+    assert.throws(()=>resolveDeploymentProfile('public_ip',{...nat,CTYUN_PUBLIC_WORKER_PROFILE_JSON:JSON.stringify(raw)}));
+  }
+});
+test('default NAT image and protected resources remain unchanged',()=>{
+  const result=resolveDeploymentProfile('private_nat',{...nat,WORKER_PROTECTED_IMAGE_IDS:'nat-protected'});
+  assert.equal(result.WORKER_REGION_ID,nat.WORKER_REGION_ID);
+  assert.equal(result.WORKER_PUBLIC_IP,'false');
+  assert.equal(result.WORKER_PROTECTED_IMAGE_IDS,'nat-protected');
+});

--- a/tests/worker-image-pipeline.test.ts
+++ b/tests/worker-image-pipeline.test.ts
@@ -561,7 +561,7 @@ describe("Tianyi Cloud worker image pipeline", () => {
       imageOrchestrator,
       /"timeout"[\s\S]*?"ctyun-cli"/,
     );
-    assert.match(imageOrchestrator, /"--extIP", "0"/);
+    assert.match(imageOrchestrator, /"--extIP", \$\(if \([\$]PublicIP\)/);
     assert.match(imageOrchestrator, /"--userData", \$userData/);
     assert.match(imageOrchestrator, /userData exceeds Tianyi Cloud's 16384-character limit/);
     assert.match(imageOrchestrator, /curl_common=[(]--fail --silent --show-error --location --ipv4/);
@@ -1070,6 +1070,7 @@ process.exit(result.status ?? 1);
         buildNumber: string,
         imageName: string,
         scenario = "",
+        extraArgs: string[] = [],
       ) =>
         spawnSync(
           "pwsh",
@@ -1120,6 +1121,7 @@ process.exit(result.status ?? 1);
             "subnet-test",
             "-SecurityGroupID",
             "security-group-test",
+            ...extraArgs,
           ],
           {
             cwd: root,
@@ -1276,6 +1278,7 @@ process.exit(result.status ?? 1);
         "1000",
         "catsco-worker-test-1000",
         "foreign-image",
+        ["-PublicIP"],
       );
       assert.notEqual(foreignResult.status, 0);
       assert.match(
@@ -1287,6 +1290,8 @@ process.exit(result.status ?? 1);
       assert.match(foreignCalls, /ecs DeleteEcsInstance/);
       assert.match(foreignCalls, /ecs DeleteEcsKeypair/);
       const foreignState = JSON.parse(fs.readFileSync(statePath, "utf8"));
+      assert.equal(foreignState.createExtIP, "1");
+      assert.equal(foreignState.createHadBandwidth, true);
       assert.equal(foreignState.imageExists, true);
       assert.equal(foreignState.instanceExists, false);
       assert.equal(foreignState.keyExists, false);


### PR DESCRIPTION
Adds a `public_ip` option to the protected Worker image workflow for Foshan 7 while keeping tag/default NAT baking unchanged. One validated configuration supplies bake, reconciliation and image pruning; public builders use independent outbound IPv4 and the prepared image enforces key-based SSH before identity cleanup.

Validation: 16 image pipeline/profile tests passed, including mocked public-IP allocation and compensating cleanup. No real Foshan image has been baked yet: the workflow requires the implementation on trusted `main`. The `release-prod` public profile variable is configured with the dedicated network; existing NAT variables are unchanged.

The feature also requires linked CatsCompany control-plane and Relay admin PRs. Deploy those and perform actual CN/CC user creation, SSH, Artifact and lifecycle acceptance after the first image bake. This PR does not publish a desktop release.

关联 PR：XiaoBa https://github.com/buildsense-ai/XiaoBa-CLI/pull/459 · CatsCompany https://github.com/buildsense-ai/cats-company/pull/424 · Relay https://github.com/buildsense-ai/cats-bifrost-deploy/pull/95

