### PR TITLE
fix: 切换 Agent 前验证 Runtime 绑定

### DIFF
--- a/src/catscompany/bot-switch-guard.ts
+++ b/src/catscompany/bot-switch-guard.ts
@@ -1,0 +1,101 @@
+const DEFAULT_CATSCO_HTTP_BASE_URL = 'https://app.catsco.cc';
+const DEFAULT_TIMEOUT_MS = 2_500;
+
+export type CatsCoBotSwitchGuardCode =
+  | 'BOT_BINDING_UNVERIFIED'
+  | 'BOT_BOUND_TO_OTHER_RUNTIME';
+
+export class CatsCoBotSwitchGuardError extends Error {
+  constructor(
+    public readonly code: CatsCoBotSwitchGuardCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'CatsCoBotSwitchGuardError';
+  }
+}
+
+export interface VerifyCatsCoBotSwitchBindingOptions {
+  httpBaseUrl?: string;
+  token?: string;
+  botUid?: string;
+  localBodyId?: string;
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+}
+
+export interface VerifiedCatsCoBotSwitchBinding {
+  botUid: string;
+  localBodyId: string;
+  platformBodyId?: string;
+  bound: boolean;
+}
+
+export async function verifyCatsCoBotSwitchBinding(
+  options: VerifyCatsCoBotSwitchBindingOptions,
+): Promise<VerifiedCatsCoBotSwitchBinding> {
+  const token = String(options.token || '').trim();
+  const botUid = String(options.botUid || '').trim();
+  const localBodyId = String(options.localBodyId || '').trim();
+  const httpBaseUrl = String(options.httpBaseUrl || DEFAULT_CATSCO_HTTP_BASE_URL)
+    .trim()
+    .replace(/\/+$/, '');
+  if (!token || !/^\d+$/.test(botUid) || Number(botUid) <= 0 || !localBodyId || !httpBaseUrl) {
+    throw unverified('无法确认目标 Agent 的运行环境绑定，已停止切换。');
+  }
+
+  const fetchImpl = options.fetchImpl || fetch;
+  const timeoutMs = Number.isFinite(options.timeoutMs) && Number(options.timeoutMs) > 0
+    ? Number(options.timeoutMs)
+    : DEFAULT_TIMEOUT_MS;
+  let response: Response;
+  try {
+    response = await fetchImpl(
+      `${httpBaseUrl}/api/bots/body-status?uid=${encodeURIComponent(botUid)}`,
+      {
+        method: 'GET',
+        headers: { Authorization: `Bearer ${token}`, Accept: 'application/json' },
+        signal: AbortSignal.timeout(timeoutMs),
+      },
+    );
+  } catch {
+    throw unverified('CatsCo 暂时无法确认目标 Agent 的运行环境绑定，已停止切换。');
+  }
+  if (!response.ok) {
+    throw unverified(`CatsCo 无法确认目标 Agent 的运行环境绑定（HTTP ${response.status}），已停止切换。`);
+  }
+
+  let payload: Record<string, unknown>;
+  try {
+    payload = await response.json() as Record<string, unknown>;
+  } catch {
+    throw unverified('CatsCo 返回了无法识别的运行环境状态，已停止切换。');
+  }
+  const responseBotUid = String(payload.bot_uid || payload.botUid || '').trim();
+  const bound = payload.bound;
+  const platformBodyId = String(payload.body_id || payload.bodyId || '').trim();
+  if (
+    responseBotUid !== botUid
+    || typeof bound !== 'boolean'
+    || (bound === true && !platformBodyId)
+    || (bound === false && Boolean(platformBodyId))
+  ) {
+    throw unverified('CatsCo 返回了不完整的运行环境绑定状态，已停止切换。');
+  }
+  if (bound && platformBodyId !== localBodyId) {
+    throw new CatsCoBotSwitchGuardError(
+      'BOT_BOUND_TO_OTHER_RUNTIME',
+      '目标 Agent 已绑定另一台 XiaoBa Runtime，已停止切换。',
+    );
+  }
+  return {
+    botUid,
+    localBodyId,
+    platformBodyId: platformBodyId || undefined,
+    bound,
+  };
+}
+
+function unverified(message: string): CatsCoBotSwitchGuardError {
+  return new CatsCoBotSwitchGuardError('BOT_BINDING_UNVERIFIED', message);
+}

--- a/src/catscompany/skillhub-rpc.ts
+++ b/src/catscompany/skillhub-rpc.ts
@@ -23,6 +23,10 @@ import {
 } from '../skillhub/local-share';
 import { PathResolver } from '../utils/path-resolver';
 import { Logger } from '../utils/logger';
+import {
+  CatsCoBotSwitchGuardError,
+  verifyCatsCoBotSwitchBinding,
+} from './bot-switch-guard';
 
 export const SKILLHUB_THIN_RPC_TOOLS = {
   workspace: 'skillhub.localWorkspace.get',
@@ -93,7 +97,8 @@ export class SkillHubThinRpcError extends Error {
 
 export interface SkillHubThinRpcHandlerOptions {
   runtimeRoot?: string;
-  scheduleBotSwitch?: (botUid: string) => void;
+  scheduleBotSwitch?: (botUid: string, expectedCurrentBotUid: string) => void;
+  verifyBotSwitchBinding?: typeof verifyCatsCoBotSwitchBinding;
   finalizeCurrentBotSkill?: typeof finalizeCurrentBotPublicSkillNow;
   pushCurrentBotSkillWorkspace?: typeof pushCurrentBotSkillWorkspaceToCloudNow;
   isShuttingDown?: () => boolean;
@@ -104,7 +109,8 @@ export interface SkillHubThinRpcHandlerOptions {
 
 export class SkillHubThinRpcHandler {
   private readonly runtimeRoot: string;
-  private readonly scheduleBotSwitch: (botUid: string) => void;
+  private readonly scheduleBotSwitch: (botUid: string, expectedCurrentBotUid: string) => void;
+  private readonly verifyBotSwitchBinding: typeof verifyCatsCoBotSwitchBinding;
   private readonly finalizeCurrentBotSkill: typeof finalizeCurrentBotPublicSkillNow;
   private readonly pushCurrentBotSkillWorkspace: typeof pushCurrentBotSkillWorkspaceToCloudNow;
   private readonly isShuttingDown: () => boolean;
@@ -121,7 +127,12 @@ export class SkillHubThinRpcHandler {
     this.runtimeRoot = path.resolve(options.runtimeRoot ?? PathResolver.getRuntimeDataRoot());
     this.isShuttingDown = options.isShuttingDown ?? (() => false);
     this.scheduleBotSwitch = options.scheduleBotSwitch
-      ?? ((botUid) => scheduleDashboardBotSwitch(botUid, this.isShuttingDown));
+      ?? ((botUid, expectedCurrentBotUid) => scheduleDashboardBotSwitch(
+        botUid,
+        expectedCurrentBotUid,
+        this.isShuttingDown,
+      ));
+    this.verifyBotSwitchBinding = options.verifyBotSwitchBinding ?? verifyCatsCoBotSwitchBinding;
     this.finalizeCurrentBotSkill = options.finalizeCurrentBotSkill
       ?? finalizeCurrentBotPublicSkillNow;
     this.pushCurrentBotSkillWorkspace = options.pushCurrentBotSkillWorkspace
@@ -188,7 +199,19 @@ export class SkillHubThinRpcHandler {
     const scope = this.assertRequestScope(request, botUid, request.tool_name !== SKILLHUB_THIN_RPC_TOOLS.switchBot);
 
     if (request.tool_name === SKILLHUB_THIN_RPC_TOOLS.switchBot) {
-      this.scheduleBotSwitch(botUid);
+      const expectedCurrentBotUid = await this.preflightBotSwitch(botUid);
+      this.assertOperational(request);
+      this.assertRequestScope(request, botUid, false);
+      const currentBotUid = String(
+        createCatsCoLocalConfigService({ runtimeRoot: this.runtimeRoot }).load().currentBot?.uid || '',
+      ).trim();
+      if (currentBotUid !== expectedCurrentBotUid) {
+        throw new SkillHubThinRpcError(
+          'BOT_SWITCH_STALE',
+          'The active local Bot changed while the SkillHub switch was being verified.',
+        );
+      }
+      this.scheduleBotSwitch(botUid, expectedCurrentBotUid);
       return {
         schema: 'xiaoba.skillhub.bot_switch.v1',
         bot_uid: botUid,
@@ -210,6 +233,28 @@ export class SkillHubThinRpcHandler {
       default:
         throw new SkillHubThinRpcError('TOOL_NOT_FOUND', 'Unsupported SkillHub device operation.');
     }
+  }
+
+  private async preflightBotSwitch(botUid: string): Promise<string> {
+    const config = createCatsCoLocalConfigService({ runtimeRoot: this.runtimeRoot }).load();
+    const expectedCurrentBotUid = String(config.currentBot?.uid || '').trim();
+    try {
+      await this.verifyBotSwitchBinding({
+        httpBaseUrl: config.endpoints?.httpBaseUrl,
+        token: config.account?.token,
+        botUid,
+        localBodyId: config.device?.bodyId,
+      });
+    } catch (error) {
+      if (error instanceof CatsCoBotSwitchGuardError) {
+        throw new SkillHubThinRpcError(error.code, error.message);
+      }
+      throw new SkillHubThinRpcError(
+        'BOT_BINDING_UNVERIFIED',
+        'CatsCo could not verify the target Bot Runtime binding.',
+      );
+    }
+    return expectedCurrentBotUid;
   }
 
   private async readWorkspace(
@@ -752,13 +797,19 @@ function buildWorkspacePageResponse(
 
 export function scheduleDashboardBotSwitch(
   botUid: string,
-  isShuttingDown: () => boolean = () => false,
+  expectedCurrentBotUidOrShutdown: string | (() => boolean) = '',
+  maybeIsShuttingDown: () => boolean = () => false,
 ): void {
-  dashboardBotSwitchScheduler.schedule(botUid, isShuttingDown);
+  dashboardBotSwitchScheduler.schedule(
+    botUid,
+    expectedCurrentBotUidOrShutdown,
+    maybeIsShuttingDown,
+  );
 }
 
 interface PendingDashboardBotSwitch {
   botUid: string;
+  expectedCurrentBotUid: string;
   isShuttingDown: () => boolean;
 }
 
@@ -769,12 +820,25 @@ export class DashboardBotSwitchScheduler {
   private runningBotUid = '';
 
   constructor(
-    private readonly requestSwitch: (botUid: string) => Promise<void> = requestDashboardBotSwitch,
+    private readonly requestSwitch: (botUid: string, expectedCurrentBotUid: string) => Promise<void> = (
+      botUid,
+      expectedCurrentBotUid,
+    ) => requestDashboardBotSwitch(botUid, fetch, expectedCurrentBotUid),
     private readonly delayMs = 1_000,
   ) {}
 
-  schedule(botUid: string, isShuttingDown: () => boolean = () => false): void {
+  schedule(
+    botUid: string,
+    expectedCurrentBotUidOrShutdown: string | (() => boolean) = '',
+    maybeIsShuttingDown: () => boolean = () => false,
+  ): void {
     const target = String(botUid || '').trim();
+    const expectedCurrentBotUid = typeof expectedCurrentBotUidOrShutdown === 'string'
+      ? expectedCurrentBotUidOrShutdown
+      : '';
+    const isShuttingDown = typeof expectedCurrentBotUidOrShutdown === 'function'
+      ? expectedCurrentBotUidOrShutdown
+      : maybeIsShuttingDown;
     if (!target || isShuttingDown()) return;
     if (this.running && this.runningBotUid === target) {
       this.pending = undefined;
@@ -782,12 +846,13 @@ export class DashboardBotSwitchScheduler {
     }
     if (this.pending?.botUid === target) {
       // Refresh the connector lifecycle fence without extending the debounce.
-      this.pending = { botUid: target, isShuttingDown };
+      this.pending = { botUid: target, expectedCurrentBotUid, isShuttingDown };
       return;
     }
 
     this.pending = {
       botUid: target,
+      expectedCurrentBotUid,
       isShuttingDown,
     };
     if (!this.running) this.arm();
@@ -815,7 +880,7 @@ export class DashboardBotSwitchScheduler {
     this.running = true;
     this.runningBotUid = next.botUid;
     try {
-      await this.requestSwitch(next.botUid);
+      await this.requestSwitch(next.botUid, next.expectedCurrentBotUid);
     } catch (error: any) {
       Logger.warning(`SkillHub remote Bot switch failed: ${error?.message || String(error)}`);
     } finally {
@@ -831,6 +896,7 @@ const dashboardBotSwitchScheduler = new DashboardBotSwitchScheduler();
 export async function requestDashboardBotSwitch(
   botUid: string,
   fetchImpl: typeof fetch = fetch,
+  expectedCurrentBotUid = '',
 ): Promise<void> {
   const numericPort = Number(process.env.XIAOBA_DASHBOARD_PORT || 3800);
   const port = Number.isSafeInteger(numericPort) && numericPort > 0 && numericPort <= 65535
@@ -843,7 +909,11 @@ export async function requestDashboardBotSwitch(
       'Content-Type': 'application/json',
       ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
     },
-    body: JSON.stringify({ botUid }),
+    body: JSON.stringify({
+      botUid,
+      source: 'skillhub-thin-rpc',
+      expectedCurrentBotUid,
+    }),
   });
   if (!response.ok) {
     throw new Error(`Dashboard rejected the Bot switch (HTTP ${response.status}).`);

--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -56,6 +56,10 @@ import {
 } from '../../runtime/runtime-profile-editor';
 import { inferCatsUploadType, uploadCatsLocalFile } from '../../catscompany/upload';
 import { createCatsCoLocalConfigService } from '../../catscompany/local-config';
+import {
+  CatsCoBotSwitchGuardError,
+  verifyCatsCoBotSwitchBinding,
+} from '../../catscompany/bot-switch-guard';
 import { CATSCO_APP_HTTP_ORIGINS, isCatsRelayApiBase, isCatsCoWebSocketEndpoint } from '../../utils/catsco-domains';
 import { catalogRuntimeMatchesModelId, createBotDefinitionSyncService } from '../../bot-definition/service';
 import { prepareBoundBotDefinition } from '../../bot-definition/activation';
@@ -361,6 +365,12 @@ function p2pTopicId(uid1: string | number, uid2: string | number): string {
 function httpError(message: string, status: number): Error {
   const error = new Error(message);
   (error as any).status = status;
+  return error;
+}
+
+function codedHttpError(message: string, status: number, code: string): Error {
+  const error = httpError(message, status);
+  (error as any).code = code;
   return error;
 }
 
@@ -849,6 +859,43 @@ async function getCatsBotBodyStatus(
       checkedAt: new Date().toISOString(),
       error: String(error?.message || 'unable to query CatsCo body status'),
     };
+  }
+}
+
+async function assertSkillHubBotSwitchBinding(
+  state: CatsAuthState,
+  botUid: string,
+  expectedCurrentBotUid: string,
+): Promise<void> {
+  const localConfig = createCatsCoLocalConfigService({ runtimeRoot: runtimeDataRoot() }).load();
+  const currentBotUid = String(localConfig.currentBot?.uid || '').trim();
+  if (!expectedCurrentBotUid || currentBotUid !== expectedCurrentBotUid) {
+    throw codedHttpError(
+      '本地 Agent 已在验证期间发生变化，已停止执行过期的 SkillHub 切换请求。',
+      409,
+      'BOT_SWITCH_STALE',
+    );
+  }
+  try {
+    await verifyCatsCoBotSwitchBinding({
+      httpBaseUrl: state.httpBaseUrl,
+      token: state.token,
+      botUid,
+      localBodyId: localConfig.device?.bodyId,
+    });
+  } catch (error) {
+    if (error instanceof CatsCoBotSwitchGuardError) {
+      throw codedHttpError(
+        error.message,
+        error.code === 'BOT_BOUND_TO_OTHER_RUNTIME' ? 409 : 503,
+        error.code,
+      );
+    }
+    throw codedHttpError(
+      '暂时无法确认目标 Agent 的运行环境绑定，已停止切换。',
+      503,
+      'BOT_BINDING_UNVERIFIED',
+    );
   }
 }
 
@@ -2106,6 +2153,9 @@ function sanitizeCatsErrorMessage(value: unknown): string {
 
 function catsErrorResponse(error: any): { status: number; body: Record<string, unknown> } {
   const body: Record<string, unknown> = { error: sanitizeCatsErrorMessage(error.message) };
+  if (typeof error?.code === 'string' && /^[A-Z0-9_]{1,80}$/.test(error.code)) {
+    body.code = error.code;
+  }
   const data = sanitizeCatsErrorData(error.data);
   if (data) body.data = data;
   return { status: error.status || 500, body };
@@ -4092,6 +4142,13 @@ export function createApiRouter(
         env: process.env,
       });
       const apiKey = await getCatsBotApiKey(state, botUid, targetBot);
+      if (String(req.body?.source || '').trim() === 'skillhub-thin-rpc') {
+        await assertSkillHubBotSwitchBinding(
+          state,
+          botUid,
+          String(req.body?.expectedCurrentBotUid || '').trim(),
+        );
+      }
       const result = await commitCatsBotBindingAndStartConnector(serviceManager, state, {
         userUid,
         username: me.username || state.username || '',

--- a/tests/catscompany-skillhub-rpc.test.ts
+++ b/tests/catscompany-skillhub-rpc.test.ts
@@ -24,6 +24,10 @@ import {
 } from '../src/skillhub/local-skill-metadata';
 import { SkillHubService } from '../src/skillhub/service';
 import { trashBotSkill } from '../src/bot-skills/deleted-skill-trash';
+import {
+  CatsCoBotSwitchGuardError,
+  verifyCatsCoBotSwitchBinding,
+} from '../src/catscompany/bot-switch-guard';
 
 describe('CatsCompany SkillHub thin RPC', () => {
   let runtimeRoot = '';
@@ -62,6 +66,12 @@ describe('CatsCompany SkillHub thin RPC', () => {
     handler = new SkillHubThinRpcHandler({
       runtimeRoot,
       scheduleBotSwitch: (botUid) => scheduledBotUIDs.push(botUid),
+      verifyBotSwitchBinding: async ({ botUid, localBodyId }) => ({
+        botUid: String(botUid),
+        localBodyId: String(localBodyId),
+        platformBodyId: String(localBodyId),
+        bound: true,
+      }),
       now: () => new Date('2026-08-24T00:00:00.000Z'),
     });
   });
@@ -850,6 +860,105 @@ describe('CatsCompany SkillHub thin RPC', () => {
     assert.deepEqual(scheduledBotUIDs, ['44']);
   });
 
+  test('rejects a Bot switch when the target is bound to another Runtime body', async () => {
+    const guardedHandler = new SkillHubThinRpcHandler({
+      runtimeRoot,
+      scheduleBotSwitch: (botUid) => scheduledBotUIDs.push(botUid),
+      verifyBotSwitchBinding: async () => {
+        throw new CatsCoBotSwitchGuardError(
+          'BOT_BOUND_TO_OTHER_RUNTIME',
+          'target Bot is bound elsewhere',
+        );
+      },
+    });
+    await assert.rejects(
+      guardedHandler.execute(request({
+        request_id: 'switch-bound-elsewhere',
+        tool_name: SKILLHUB_THIN_RPC_TOOLS.switchBot,
+        payload: { bot_uid: '44' },
+      })),
+      (error: unknown) => (
+        error instanceof SkillHubThinRpcError
+        && error.code === 'BOT_BOUND_TO_OTHER_RUNTIME'
+      ),
+    );
+    assert.deepEqual(scheduledBotUIDs, []);
+  });
+
+  test('rejects a verified Bot switch when the active local Bot changes before scheduling', async () => {
+    const guardedHandler = new SkillHubThinRpcHandler({
+      runtimeRoot,
+      scheduleBotSwitch: (botUid) => scheduledBotUIDs.push(botUid),
+      verifyBotSwitchBinding: async ({ botUid, localBodyId }) => {
+        const configService = createCatsCoLocalConfigService({ runtimeRoot });
+        const config = configService.load();
+        configService.save({
+          ...config,
+          currentBot: {
+            ...config.currentBot!,
+            uid: '55',
+          },
+        });
+        return {
+          botUid: String(botUid),
+          localBodyId: String(localBodyId),
+          platformBodyId: String(localBodyId),
+          bound: true,
+        };
+      },
+    });
+    await assert.rejects(
+      guardedHandler.execute(request({
+        request_id: 'switch-stale-current-bot',
+        tool_name: SKILLHUB_THIN_RPC_TOOLS.switchBot,
+        payload: { bot_uid: '44' },
+      })),
+      (error: unknown) => (
+        error instanceof SkillHubThinRpcError
+        && error.code === 'BOT_SWITCH_STALE'
+      ),
+    );
+    assert.deepEqual(scheduledBotUIDs, []);
+  });
+
+  test('fails closed when CatsCo cannot verify the target Bot binding', async () => {
+    await assert.rejects(
+      verifyCatsCoBotSwitchBinding({
+        httpBaseUrl: 'https://catsco.example.test',
+        token: 'owner-token',
+        botUid: '44',
+        localBodyId: 'local-body',
+        fetchImpl: async () => new Response('', { status: 502 }),
+      }),
+      (error: unknown) => (
+        error instanceof CatsCoBotSwitchGuardError
+        && error.code === 'BOT_BINDING_UNVERIFIED'
+      ),
+    );
+  });
+
+  test('treats an offline durable binding on another body as a conflict', async () => {
+    await assert.rejects(
+      verifyCatsCoBotSwitchBinding({
+        httpBaseUrl: 'https://catsco.example.test',
+        token: 'owner-token',
+        botUid: '44',
+        localBodyId: 'local-body',
+        fetchImpl: async () => Response.json({
+          bot_uid: 44,
+          state: 'offline',
+          active: false,
+          bound: true,
+          body_id: 'fermi-server-body',
+        }),
+      }),
+      (error: unknown) => (
+        error instanceof CatsCoBotSwitchGuardError
+        && error.code === 'BOT_BOUND_TO_OTHER_RUNTIME'
+      ),
+    );
+  });
+
   test('reports an in-progress workspace handoff as a retryable RPC state', async () => {
     createCatsCoLocalConfigService({ runtimeRoot }).save({
       version: 1,
@@ -1044,7 +1153,11 @@ describe('CatsCompany SkillHub thin RPC', () => {
     );
     assert.equal(calls.length, 1);
     assert.match(calls[0].url, /^http:\/\/127\.0\.0\.1:\d+\/api\/cats\/switch-bot$/);
-    assert.deepEqual(JSON.parse(String(calls[0].init?.body)), { botUid: '44' });
+    assert.deepEqual(JSON.parse(String(calls[0].init?.body)), {
+      botUid: '44',
+      source: 'skillhub-thin-rpc',
+      expectedCurrentBotUid: '',
+    });
   });
 
   test('coalesces delayed Bot switch intents so the latest selection wins', async () => {

--- a/tests/dashboard-catsco-auth-status.test.ts
+++ b/tests/dashboard-catsco-auth-status.test.ts
@@ -1294,6 +1294,15 @@ describe('dashboard CatsCo account status', () => {
           ],
         });
       }
+      if (req.path === '/api/bots/body-status') {
+        return res.json({
+          bot_uid: Number(req.query.uid),
+          state: 'offline',
+          active: false,
+          bound: true,
+          body_id: 'other-server-body',
+        });
+      }
       if (req.path === '/api/friends/request') return res.json({ ok: true });
       if (req.path === '/api/friends/accept') {
         assert.equal(req.header('authorization'), 'ApiKey new-agent-key');
@@ -1376,6 +1385,21 @@ describe('dashboard CatsCo account status', () => {
     assert.equal(weixinStopped, 1);
     assert.equal(localConfig.currentBot?.uid, '199');
     assert.equal(localConfig.currentBot?.bindingSource, 'explicit-switch');
+
+    const guardedResponse = await fetch(`${dashboardBaseUrl}/api/cats/switch-bot`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        botUid: '188',
+        source: 'skillhub-thin-rpc',
+        expectedCurrentBotUid: '199',
+      }),
+    });
+    const guardedData = await guardedResponse.json() as any;
+    assert.equal(guardedResponse.status, 409);
+    assert.equal(guardedData.code, 'BOT_BOUND_TO_OTHER_RUNTIME');
+    assert.equal(createCatsCoLocalConfigService({ runtimeRoot: testRoot }).load().currentBot?.uid, '199');
+    assert.equal(connectorRestarted, 1);
   });
 
   test('POST /cats/bind-bot restores the active binding when target preflight is blocked', async () => {


### PR DESCRIPTION
## 目标

防止 SkillHub 的远程 Agent 切换请求把本地 XiaoBa 从当前 Agent 静默切换到已绑定其他 Runtime 的 Agent。

## 变更

- SkillHub 切换进入调度前，使用 Owner 登录态查询目标 Agent 的 durable Runtime 绑定。
- 只有“明确未绑定”或“已绑定当前 body”才允许继续；502、网络失败、响应缺字段一律 fail closed。
- 即使另一 Runtime 当前离线，只要 durable binding 仍指向另一 body，也拒绝切换。
- 将当前 Agent UID 作为前置状态传到 Dashboard；Dashboard 在真正写入配置前再次校验当前 Agent 与目标绑定，阻断等待期间的竞态。
- 为结构化错误返回稳定 code，便于 WebApp 显示明确原因。

## 边界

- 仅影响来源为 `skillhub-thin-rpc` 的远程 Agent 切换。
- 普通 Dashboard 手动切换保持原行为。
- 不修改聊天、Shell、read/write/edit_file、Skill 加载或 Skill 执行权限。

## 验证

- `npm run build`
- `npx tsx --test tests/catscompany-skillhub-rpc.test.ts tests/dashboard-catsco-auth-status.test.ts tests/catscompany-runtime-device-capabilities.test.ts`
  - 76 passed
- 完整 runtime 套件本地执行：1812 passed，17 skipped，2 个与本改动无关的环境/执行顺序失败：
  - 并行 build 清理 `dist` 时，bundled knowledge 用例读到缺失产物；后续 build 已单独通过。
  - Windows Git Bash 缺少 `jq`，worker updater 用例无法进入预期断言。

## 发布顺序

1. 先合并 cats-company 前端/路由 fail-closed PR #426。
2. 再合并本 PR，形成 XiaoBa 端二次校验。
3. 最后合并 cats-company 拒绝静默 Runtime rebind 的 PR #427。

后续合法迁移到新机器应通过独立的 Owner 明确授权流程完成，不再复用 SkillHub 浏览动作隐式迁移。
