### PR TITLE
fix: retry image builder cleanup while captured disks are busy

### DIFF
--- a/ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1
+++ b/ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1
@@ -773,29 +773,31 @@ function Remove-Builder {
     }
     Assert-TemporaryBuilder $instance
     Write-Host "Deleting temporary builder $script:BuilderID"
-    try {
-        Invoke-Ctyun @(
-            "ecs", "DeleteEcsInstance",
-            "--regionID", $RegionID,
-            "--instanceID", $script:BuilderID,
-            "--clientToken", ([guid]::NewGuid().ToString()),
-            "--deleteEip", "true",
-            "--deleteVolume", "true"
-        ) | Out-Null
-    } catch {
-        # Multi-AZ resource pools (e.g. cn-huanan2) reject releasing associated
-        # resources at delete time (Ecs.Region.NotSupport). In those pools the
-        # EIP is released automatically when the instance is unsubscribed, so
-        # retry the plain delete instead of leaking the billed ECS.
-        if ($_.Exception.Message -notmatch "NotSupport") {
-            throw
+    # Image availability can precede disk unlock in Foshan. Keep one token
+    # across the bounded retry and recheck immutable ownership before each call.
+    $deleteToken = [guid]::NewGuid().ToString()
+    $deleteAssociated = $true
+    for ($attempt = 1; $attempt -le 9; $attempt++) {
+        $current = if ($attempt -eq 1) { $instance } else { Resolve-BuilderInstance }
+        if (-not $current) { break }
+        Assert-TemporaryBuilder $current
+        $deleteArgs = @(
+            "ecs", "DeleteEcsInstance", "--regionID", $RegionID,
+            "--instanceID", $script:BuilderID, "--clientToken", $deleteToken
+        )
+        if ($deleteAssociated) { $deleteArgs += @("--deleteEip", "true", "--deleteVolume", "true") }
+        try {
+            Invoke-Ctyun $deleteArgs | Out-Null
+            break
+        } catch {
+            if ($deleteAssociated -and $_.Exception.Message -match "NotSupport") {
+                $deleteAssociated = $false
+                continue
+            }
+            if ($_.Exception.Message -notmatch "Ecs\.Instance\.DiskStatusNotValid" -or $attempt -ge 9) { throw }
+            Write-BakeProgress -Phase "cleanup-disk-busy" -Detail "attempt=$attempt; waiting for captured disk to unlock" -Force
+            Wait-PollInterval -DefaultSeconds 15
         }
-        Invoke-Ctyun @(
-            "ecs", "DeleteEcsInstance",
-            "--regionID", $RegionID,
-            "--instanceID", $script:BuilderID,
-            "--clientToken", ([guid]::NewGuid().ToString())
-        ) | Out-Null
     }
 
     $deadline = Get-BoundedDeadline `

--- a/tests/worker-image-cleanup-retry.test.ts
+++ b/tests/worker-image-cleanup-retry.test.ts
@@ -1,0 +1,35 @@
+import {test} from 'node:test';
+import assert from 'node:assert/strict';
+import {spawnSync} from 'node:child_process';
+import fs from 'node:fs';
+const script=fs.readFileSync(new URL('../ops/ctyun-worker-image/New-CatsCoWorkerImage.ps1',import.meta.url),'utf8');
+const body=script.slice(script.indexOf('function Remove-Builder {'),script.indexOf('function Remove-KeyPair {'));
+for(const mode of ['busy','unsupported-then-busy','forbidden','always-busy'])test(`temporary builder deletion: ${mode}`,()=>{
+ const ps=`$ErrorActionPreference='Stop'
+$RegionID='test-region';$script:BuilderID='owned-id';$script:BuilderResourceID='owned-resource';$script:BuilderName='owned-name';$script:deleted=$false;$script:calls=@();$script:proofs=0
+function Resolve-BuilderInstance {if(-not $script:deleted){return @{instanceID='owned-id'}}}
+function Assert-TemporaryBuilder {param($i) if($i.instanceID -ne 'owned-id'){throw 'foreign'};$script:proofs++}
+function Get-BoundedDeadline {return (Get-Date).AddMinutes(1)}
+function Wait-PollInterval {}
+function Write-BakeProgress {}
+function Invoke-Ctyun {
+ param([string[]]$CliArgs)
+ $script:calls+=,@($CliArgs)
+ if('${mode}' -eq 'forbidden'){throw 'Ecs.Forbidden'}
+ if('${mode}' -eq 'unsupported-then-busy' -and $script:calls.Count -eq 1){throw 'Ecs.Region.NotSupport'}
+ if('${mode}' -eq 'always-busy' -or $script:calls.Count -lt 3){throw 'Ecs.Instance.DiskStatusNotValid'}
+ $script:deleted=$true
+}
+${body}
+$err='';try{Remove-Builder}catch{$err=$_.Exception.Message}
+[ordered]@{count=$script:calls.Count;proofs=$script:proofs;error=$err;deleted=$script:deleted;tokens=@($script:calls|ForEach-Object{$_[([array]::IndexOf($_,'--clientToken')+1)]})}|ConvertTo-Json -Compress
+`;
+ const result=spawnSync(process.platform==='win32'?'pwsh.exe':'pwsh',['-NoLogo','-NoProfile','-NonInteractive','-Command',ps],{encoding:'utf8',windowsHide:true});
+ assert.equal(result.status,0,result.stderr);
+ const row=JSON.parse(result.stdout.trim().split(/\r?\n/).at(-1)!);
+ assert.equal(new Set(row.tokens).size,1);
+ assert.equal(row.proofs,row.count+1);
+ if(mode==='forbidden'){assert.equal(row.count,1);assert.match(row.error,/Forbidden/);}
+ else if(mode==='always-busy'){assert.equal(row.count,9);assert.match(row.error,/DiskStatusNotValid/);}
+ else{assert.equal(row.count,3);assert.equal(row.deleted,true);assert.equal(row.error,'');}
+});


### PR DESCRIPTION
The real Foshan bake in #460 produced a valid image but cleanup failed with Ecs.Instance.DiskStatusNotValid until the captured disk unlocked. Retry only this specific transient failure, bounded to nine calls with one client token, preserving the regional NotSupport fallback and immutable builder ownership checks. Other errors still fail immediately. Validation: all 17 image pipeline and cleanup retry tests pass; real dual-region run 34320167183 recovered successfully through the existing rerun path.