### PR TITLE
fix: preserve operator-managed server Skill workspaces

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -25,6 +25,7 @@ const skillHubPhase1Tests = [
   'tests/catscompany-skillhub-rpc.test.ts',
   'tests/bot-definition-skills.test.ts',
   'tests/bot-skill-workspace.test.ts',
+  'tests/bot-skill-preservation.test.ts',
   'tests/bot-skill-candidate-workspace.test.ts',
   'tests/turn-skill-snapshot.test.ts',
   'tests/bot-skills-activation-state.test.ts',

--- a/src/bot-definition/activation.ts
+++ b/src/bot-definition/activation.ts
@@ -42,6 +42,12 @@ export interface PrepareBoundBotDefinitionOptions extends BotDefinitionSyncServi
   cloudSelection?: CloudBotModelSelection;
   acknowledgeCloudSelection?: boolean;
   prepareSkills?: boolean;
+  /**
+   * The active Skill workspace is managed out of band by the server operator.
+   * Skip implicit Skill reconciliation while still allowing the model/prompt
+   * portion of a unified BotDefinition revision to become active.
+   */
+  preserveSkills?: boolean;
   /** Hot reload must not silently fall back to legacy/local startup after a failed cloud read. */
   requireCloud?: boolean;
 }
@@ -219,7 +225,7 @@ export async function prepareBoundBotDefinition(
           cloudSnapshot = await cloudDefinitionSync.pushPrompt(botId, auth, definition.prompt)
             ?? cloudSnapshot;
         }
-        const skillSync = options.prepareSkills === false
+        const skillSync = options.prepareSkills === false || options.preserveSkills
           ? undefined
           : await prepareBoundBotSkills({
               runtimeRoot: options.runtimeRoot,
@@ -236,7 +242,7 @@ export async function prepareBoundBotDefinition(
           options.prepareSkills === false
           && cloudSnapshot.definition?.skills === undefined
         );
-        const targetRevisionApplied = skippedSkillsAreAbsent || Boolean(
+        const targetRevisionApplied = options.preserveSkills || skippedSkillsAreAbsent || Boolean(
           skillSync
           && (skillApplyStatus === 'applied' || skillApplyStatus === 'already_applied')
           && skillSync.sync?.desiredRevision === desiredRevision

--- a/src/bot-definition/activation.ts
+++ b/src/bot-definition/activation.ts
@@ -571,6 +571,7 @@ export async function prepareBoundBotDefinition(
   });
   const skillSync = (
     options.prepareSkills === false
+    || options.preserveSkills
     || (cloudSelection && !cloudSelection.definition)
   )
     ? undefined

--- a/src/bot-skills/local-manifest.ts
+++ b/src/bot-skills/local-manifest.ts
@@ -89,6 +89,8 @@ export interface ScanBotSkillWorkspaceOptions {
   maxTotalPackageBytes?: number;
   /** Keeps content hashes but clears `files`; never use this for upload/materialization. */
   retainPackageContents?: boolean;
+  /** Read-only callers must not materialize local marker files as a side effect. */
+  writeMarkers?: boolean;
 }
 
 interface BotSkillPackageByteBudget {
@@ -98,6 +100,8 @@ interface BotSkillPackageByteBudget {
 
 interface ScanLocalBotSkillOptions {
   packageByteBudget?: BotSkillPackageByteBudget;
+  /** Defaults to true for mutating and synchronization paths. */
+  writeMarker?: boolean;
 }
 
 export function scanBotSkillWorkspace(
@@ -141,20 +145,24 @@ export function scanBotSkillWorkspace(
         }
         let manifestEntry: LocalBotSkillManifestEntry;
         try {
-          manifestEntry = scanLocalBotSkill(skillDir, root, { packageByteBudget });
+          manifestEntry = scanLocalBotSkill(skillDir, root, {
+            packageByteBudget,
+            writeMarker: options.writeMarkers !== false,
+          });
         } catch (error) {
           if (!(error instanceof BotSkillPackageValidationError) || !options.onValidationFailure) {
             throw error;
           }
-          const marker = readBotSkillLocalMarker(skillDir);
-          if (!marker) throw error;
           const name = readLocalSkillNameForValidationFailure(skillDir);
-          if (localSkillIds.has(marker.localSkillId)) {
-            throw new Error(`Bot Skill workspace contains a duplicate localSkillId: ${marker.localSkillId}`);
+          const marker = readBotSkillLocalMarker(skillDir);
+          const localSkillId = marker?.localSkillId
+            || deterministicLocalSkillId(skillDir, root, 'invalid-skill');
+          if (localSkillIds.has(localSkillId)) {
+            throw new Error(`Bot Skill workspace contains a duplicate localSkillId: ${localSkillId}`);
           }
-          localSkillIds.add(marker.localSkillId);
+          localSkillIds.add(localSkillId);
           options.onValidationFailure({
-            localSkillId: marker.localSkillId,
+            localSkillId,
             name,
             installName: path.relative(root, skillDir).replace(/\\/g, '/'),
             path: skillDir,
@@ -198,9 +206,12 @@ export function scanLocalBotSkill(
     throw new Error(`Skill has an unsafe SKILL.md: ${root}`);
   }
   assertRealPathContained(fs.realpathSync(root), skillFile);
-  const marker = ensureBotSkillLocalMarker(root);
   const files = collectBotSkillPackageFiles(root, options.packageByteBudget);
   const contentHash = computeBotSkillPackageHash(files);
+  const marker = ensureBotSkillLocalMarker(root, {
+    write: options.writeMarker !== false,
+    localSkillId: deterministicLocalSkillId(root, workspaceRoot, contentHash),
+  });
   const reference = marker.reference?.contentHash === contentHash
     ? marker.reference
     : undefined;
@@ -282,7 +293,10 @@ export function computeBotSkillPackageHash(files: readonly BotSkillPackageFile[]
   return sha256(Buffer.from(JSON.stringify(entries), 'utf8'));
 }
 
-function ensureBotSkillLocalMarker(skillDir: string): BotSkillLocalMarker {
+function ensureBotSkillLocalMarker(
+  skillDir: string,
+  options: { write: boolean; localSkillId: string },
+): BotSkillLocalMarker {
   const existing = readBotSkillLocalMarker(skillDir);
   if (existing) return existing;
   if (fs.existsSync(path.join(skillDir, BOT_SKILL_LOCAL_MARKER_FILE))) {
@@ -294,11 +308,26 @@ function ensureBotSkillLocalMarker(skillDir: string): BotSkillLocalMarker {
     : undefined;
   const marker: BotSkillLocalMarker = {
     schema: BOT_SKILL_LOCAL_MARKER_SCHEMA,
-    localSkillId: crypto.randomUUID(),
+    // Read-only scans and the first later mutating scan must agree on identity;
+    // otherwise a user-selected unmarked Skill can no longer be found when it
+    // is shared. Existing persisted marker identities remain authoritative.
+    localSkillId: options.localSkillId,
     ...(origin ? { origin } : {}),
   };
-  writeBotSkillLocalMarker(skillDir, marker);
+  if (options.write) writeBotSkillLocalMarker(skillDir, marker);
   return marker;
+}
+
+function deterministicLocalSkillId(
+  skillDir: string,
+  workspaceRoot: string | undefined,
+  contentHash: string,
+): string {
+  const root = workspaceRoot ? path.resolve(workspaceRoot) : undefined;
+  const relative = root
+    ? path.relative(root, path.resolve(skillDir)).replace(/\\/g, '/')
+    : path.basename(path.resolve(skillDir));
+  return `local-${sha256(Buffer.from(`${relative}\0${contentHash}`, 'utf8')).slice(0, 48)}`;
 }
 
 export function collectBotSkillPackageFiles(

--- a/src/bot-skills/preservation.ts
+++ b/src/bot-skills/preservation.ts
@@ -1,0 +1,36 @@
+import * as path from 'path';
+import { PathResolver } from '../utils/path-resolver';
+import { BotSkillWorkspaceService } from './workspace';
+
+/**
+ * Server operators may deliberately attach XiaoBa to an already-populated
+ * Skill workspace. In that mode startup and Bot binding must not reconcile or
+ * bootstrap the workspace as a side effect. Explicit owner-initiated SkillHub
+ * publication and deletion operations remain available.
+ */
+export function preserveOperatorManagedSkills(
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return /^(1|true|yes)$/i.test(String(env.XIAOBA_PRESERVE_SKILLS || '').trim());
+}
+
+/**
+ * Preservation is only safe when the existing active workspace is already
+ * attributed to the Bot that will use it. Never adopt or switch ownership in
+ * this mode: an absent or mismatched record requires explicit operator repair.
+ */
+export function assertOperatorManagedSkillWorkspaceBinding(
+  runtimeRoot: string,
+  botId: string,
+): void {
+  const resolvedRuntimeRoot = path.resolve(runtimeRoot);
+  const skillsRoot = PathResolver.getRuntimeDataRoot() === resolvedRuntimeRoot
+    ? PathResolver.getSkillsPath()
+    : path.join(resolvedRuntimeRoot, 'skills');
+  const activeBotId = new BotSkillWorkspaceService(resolvedRuntimeRoot, skillsRoot).getActiveBotId();
+  if (activeBotId !== botId) {
+    throw new Error(
+      `Operator-managed Skill workspace ownership mismatch: expected ${botId}, found ${activeBotId || 'none'}.`,
+    );
+  }
+}

--- a/src/catscompany/skillhub-rpc.ts
+++ b/src/catscompany/skillhub-rpc.ts
@@ -315,6 +315,7 @@ export class SkillHubThinRpcHandler {
       maxSkillEntries: MAX_WORKSPACE_SKILLS,
       maxTotalPackageBytes: MAX_WORKSPACE_PACKAGE_BYTES,
       retainPackageContents: false,
+      writeMarkers: false,
     }).filter((entry) => {
       const error = validateSkillHubShareMetadata(entry.path);
       if (!error) return true;

--- a/src/commands/catscompany.ts
+++ b/src/commands/catscompany.ts
@@ -65,7 +65,7 @@ export async function catscompanyCommand(): Promise<void> {
   const preparedBot = await prepareBoundBotDefinition({
     runtimeRoot,
     acknowledgeCloudSelection: false,
-    prepareSkills: !preserveSkills,
+    preserveSkills,
   });
   if (preserveSkills && preparedBot?.botId) {
     assertOperatorManagedSkillWorkspaceBinding(runtimeRoot, preparedBot.botId);
@@ -312,6 +312,7 @@ export async function catscompanyCommand(): Promise<void> {
 
 interface ApplyCloudModelRuntimeSelectionOptions {
   runtimeRoot: string;
+  env?: NodeJS.ProcessEnv;
   connectorConfig: CatsCompanyConfig;
   currentBot(): CatsCompanyBot;
   replaceBot(bot: CatsCompanyBot): void;
@@ -452,6 +453,7 @@ async function applyCloudBotDefinitionSelection(
   options: ApplyCloudModelRuntimeSelectionOptions,
 ): Promise<'applied' | 'deferred'> {
   const incoming = options.selection.definition!;
+  const preserveSkills = preserveOperatorManagedSkills(options.env);
   const definitionService = createBotDefinitionSyncService({ runtimeRoot: options.runtimeRoot });
   const previousDefinition = definitionService.read(options.botId)
     ?? definitionService.pullOrBootstrap(options.botId)?.definition;
@@ -500,9 +502,11 @@ async function applyCloudBotDefinitionSelection(
     if (effectiveIncoming) definitionService.acceptCanonical(effectiveIncoming);
     prepared = await prepareBoundBotDefinition({
       runtimeRoot: options.runtimeRoot,
+      env: options.env,
       botId: options.botId,
       auth: options.auth,
       acknowledgeCloudSelection: false,
+      preserveSkills,
       requireCloud: true,
     });
   } catch (error) {

--- a/src/commands/catscompany.ts
+++ b/src/commands/catscompany.ts
@@ -32,6 +32,10 @@ import {
   isBotSkillActivationAckWorkerEnabled,
   type BotSkillActivationAckWarningCode,
 } from '../bot-skills/activation-ack-worker';
+import {
+  assertOperatorManagedSkillWorkspaceBinding,
+  preserveOperatorManagedSkills,
+} from '../bot-skills/preservation';
 
 const CONNECTOR_OWNER_POLL_MS = 2000;
 const CLOUD_MODEL_POLL_MS = 5000;
@@ -57,10 +61,15 @@ export function resolveCatsCoCommandConfig(
  */
 export async function catscompanyCommand(): Promise<void> {
   const runtimeRoot = PathResolver.getRuntimeDataRoot();
+  const preserveSkills = preserveOperatorManagedSkills();
   const preparedBot = await prepareBoundBotDefinition({
     runtimeRoot,
     acknowledgeCloudSelection: false,
+    prepareSkills: !preserveSkills,
   });
+  if (preserveSkills && preparedBot?.botId) {
+    assertOperatorManagedSkillWorkspaceBinding(runtimeRoot, preparedBot.botId);
+  }
   if (preparedBot?.cloudRevision !== undefined) {
     Logger.info(`CatsCo bot ${preparedBot.botId} 已准备云端模型配置 revision=${preparedBot.cloudRevision}。`);
   } else if (preparedBot?.initializedDefault) {

--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -967,7 +967,7 @@ async function commitCatsBotBindingAndStartConnector(
       botId: input.botUid,
       selectedCatalogRuntime: input.selectedCatalogRuntime,
       acknowledgeCloudSelection: false,
-      prepareSkills: !preserveSkills,
+      preserveSkills,
     });
     const botDefinitionSync = toBotDefinitionSyncPayload(preparedBot?.sync);
     const {
@@ -3790,7 +3790,7 @@ export function createApiRouter(
         runtimeRoot: runtimeDataRoot(),
         botId,
         acknowledgeCloudSelection: false,
-        prepareSkills: !preserveSkills,
+        preserveSkills,
       });
       const result = await startCatsCompanyConnectorIfReady(serviceManager);
       if (!result.service) {

--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -67,6 +67,10 @@ import { createBotDefinitionCloudSyncService } from '../../bot-definition/cloud-
 import { getPromptReconcileCoordinator } from '../../bot-definition/prompt-sync';
 import { rollbackPreparedBotSkills } from '../../bot-skills/runtime';
 import {
+  assertOperatorManagedSkillWorkspaceBinding,
+  preserveOperatorManagedSkills,
+} from '../../bot-skills/preservation';
+import {
   customModelDefinitionToConfig,
   modelRuntimeToConfig,
   resolveActiveBotLLMConfig,
@@ -942,6 +946,13 @@ async function commitCatsBotBindingAndStartConnector(
   connectorRestarted: boolean;
   botDefinitionSync?: Record<string, unknown>;
 }> {
+  const preserveSkills = preserveOperatorManagedSkills();
+  if (preserveSkills) {
+    // Fail before friendship checks, local binding writes, or connector
+    // lifecycle changes. Preservation mode must never adopt a workspace for a
+    // different Bot as a side effect of an otherwise valid bind request.
+    assertOperatorManagedSkillWorkspaceBinding(runtimeDataRoot(), input.botUid);
+  }
   ensureCatsDeviceId();
   const rollback = createCatsCoLocalConfigRollback();
   const promptCoordinator = getPromptReconcileCoordinator({ runtimeRoot: runtimeDataRoot() });
@@ -956,6 +967,7 @@ async function commitCatsBotBindingAndStartConnector(
       botId: input.botUid,
       selectedCatalogRuntime: input.selectedCatalogRuntime,
       acknowledgeCloudSelection: false,
+      prepareSkills: !preserveSkills,
     });
     const botDefinitionSync = toBotDefinitionSyncPayload(preparedBot?.sync);
     const {
@@ -3770,10 +3782,15 @@ export function createApiRouter(
       if (!botId) {
         return res.status(409).json({ error: 'No CatsCo bot is bound on this device' });
       }
+      const preserveSkills = preserveOperatorManagedSkills();
+      if (preserveSkills) {
+        assertOperatorManagedSkillWorkspaceBinding(runtimeDataRoot(), botId);
+      }
       const preparedBot = await prepareBoundBotDefinition({
         runtimeRoot: runtimeDataRoot(),
         botId,
         acknowledgeCloudSelection: false,
+        prepareSkills: !preserveSkills,
       });
       const result = await startCatsCompanyConnectorIfReady(serviceManager);
       if (!result.service) {

--- a/src/dashboard/server.ts
+++ b/src/dashboard/server.ts
@@ -7,6 +7,7 @@ import { ServiceManager } from './service-manager';
 import { bootstrapDefaultSkillHubSkillsOnce } from '../skillhub/default-skill-bootstrap';
 import { createDashboardAuth } from './auth';
 import { CatsConnectorAutoStart } from './cats-connector-autostart';
+import { preserveOperatorManagedSkills } from '../bot-skills/preservation';
 
 const DEFAULT_PORT = 3800;
 const activeServers: Server[] = [];
@@ -38,9 +39,13 @@ export async function startDashboard(
 
   app.use(express.json({ limit: '25mb' }));
 
-  bootstrapDefaultSkillHubSkillsOnce().catch(error => {
-    Logger.warning(`Default SkillHub bootstrap failed: ${error?.message || String(error)}`);
-  });
+  if (preserveOperatorManagedSkills()) {
+    Logger.info('Operator-managed Skill workspace preservation enabled; skipping default SkillHub bootstrap');
+  } else {
+    bootstrapDefaultSkillHubSkillsOnce().catch(error => {
+      Logger.warning(`Default SkillHub bootstrap failed: ${error?.message || String(error)}`);
+    });
+  }
 
   // Configure and apply dashboard authentication.
   // Trim the env var so whitespace-only values are treated as "not set"

--- a/tests/bot-skill-preservation.test.ts
+++ b/tests/bot-skill-preservation.test.ts
@@ -1,0 +1,51 @@
+import { describe, test } from 'node:test';
+import * as assert from 'node:assert';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  assertOperatorManagedSkillWorkspaceBinding,
+  preserveOperatorManagedSkills,
+} from '../src/bot-skills/preservation';
+import { BotSkillWorkspaceService } from '../src/bot-skills/workspace';
+
+describe('operator-managed Skill workspace preservation', () => {
+  test('is disabled by default', () => {
+    assert.equal(preserveOperatorManagedSkills({}), false);
+  });
+
+  test('accepts explicit truthy values case-insensitively', () => {
+    for (const value of ['1', 'true', 'TRUE', ' yes ']) {
+      assert.equal(preserveOperatorManagedSkills({ XIAOBA_PRESERVE_SKILLS: value }), true);
+    }
+  });
+
+  test('does not treat unrelated values as enabled', () => {
+    for (const value of ['', '0', 'false', 'no', 'enabled']) {
+      assert.equal(preserveOperatorManagedSkills({ XIAOBA_PRESERVE_SKILLS: value }), false);
+    }
+  });
+
+  test('requires the preserved workspace to belong to the selected Bot', () => {
+    const runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-preserved-skills-'));
+    try {
+      const skillsRoot = path.join(runtimeRoot, 'skills');
+      fs.mkdirSync(skillsRoot, { recursive: true });
+      assert.throws(
+        () => assertOperatorManagedSkillWorkspaceBinding(runtimeRoot, 'bot-a'),
+        /expected bot-a, found none/,
+      );
+
+      new BotSkillWorkspaceService(runtimeRoot, skillsRoot).activate('bot-a');
+      assert.doesNotThrow(
+        () => assertOperatorManagedSkillWorkspaceBinding(runtimeRoot, 'bot-a'),
+      );
+      assert.throws(
+        () => assertOperatorManagedSkillWorkspaceBinding(runtimeRoot, 'bot-b'),
+        /expected bot-b, found bot-a/,
+      );
+    } finally {
+      fs.rmSync(runtimeRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/bot-skill-preservation.test.ts
+++ b/tests/bot-skill-preservation.test.ts
@@ -3,6 +3,10 @@ import * as assert from 'node:assert';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import { prepareBoundBotDefinition } from '../src/bot-definition/activation';
+import { createBotDefinitionSyncService } from '../src/bot-definition/service';
+import { BOT_DEFINITION_SCHEMA } from '../src/bot-definition/types';
+import { createCatsCoLocalConfigService } from '../src/catscompany/local-config';
 import {
   assertOperatorManagedSkillWorkspaceBinding,
   preserveOperatorManagedSkills,
@@ -48,4 +52,93 @@ describe('operator-managed Skill workspace preservation', () => {
       fs.rmSync(runtimeRoot, { recursive: true, force: true });
     }
   });
+
+  test('keeps the workspace byte-for-byte unchanged when cloud startup falls back offline', async () => {
+    const runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-preserved-skills-offline-'));
+    try {
+      const env = { XIAOBA_PRESERVE_SKILLS: '1' } as NodeJS.ProcessEnv;
+      createCatsCoLocalConfigService({ runtimeRoot, env }).save({
+        version: 1,
+        endpoints: {
+          httpBaseUrl: 'https://cats.example.test',
+          serverUrl: 'wss://cats.example.test/v0/channels',
+        },
+        account: { token: 'owner-token', uid: 'owner-7' },
+        currentBot: {
+          uid: 'bot-43',
+          apiKey: 'bot-api-key',
+          boundByUserUid: 'owner-7',
+          bindingSource: 'test',
+        },
+      });
+      createBotDefinitionSyncService({ runtimeRoot, env }).acceptCanonical({
+        schema: BOT_DEFINITION_SCHEMA,
+        botId: 'bot-43',
+        model: {
+          kind: 'custom',
+          protocol: 'openai-responses',
+          apiBase: 'https://models.example.test/v1',
+          model: 'operator-model',
+          apiKey: 'test-model-key',
+          contextWindowTokens: 128000,
+        },
+        prompt: { selected: 'custom', customSystemPrompt: 'Operator prompt.' },
+        skills: [],
+      });
+      const skillRoot = path.join(runtimeRoot, 'skills', 'operator-local');
+      fs.mkdirSync(path.join(skillRoot, 'scripts'), { recursive: true });
+      fs.writeFileSync(path.join(skillRoot, 'SKILL.md'), [
+        '---',
+        'name: operator-local',
+        'description: Operator-managed Skill that must survive offline startup.',
+        '---',
+        '',
+        'Keep this content.',
+        '',
+      ].join('\n'));
+      fs.writeFileSync(path.join(skillRoot, 'scripts', 'run.mjs'), 'console.log("preserved");\n');
+      const before = snapshotDirectory(path.join(runtimeRoot, 'skills'));
+      const requests: string[] = [];
+      const fetchImpl = (async (input: string | URL | Request) => {
+        const url = new URL(String(input));
+        requests.push(url.pathname);
+        return Response.json({ error: 'temporarily unavailable' }, { status: 503 });
+      }) as typeof fetch;
+
+      const prepared = await prepareBoundBotDefinition({
+        runtimeRoot,
+        env,
+        fetchImpl,
+        acknowledgeCloudSelection: false,
+        preserveSkills: true,
+      });
+
+      assert.equal(prepared?.botId, 'bot-43');
+      assert.equal(prepared?.skillSync, undefined);
+      assert.deepStrictEqual(snapshotDirectory(path.join(runtimeRoot, 'skills')), before);
+      assert.equal(requests.includes('/api/bot/definition'), true);
+      assert.equal(requests.includes('/api/bot/model-config'), true);
+      assert.equal(requests.includes('/api/bot/definition/skills'), false);
+    } finally {
+      fs.rmSync(runtimeRoot, { recursive: true, force: true });
+    }
+  });
 });
+
+function snapshotDirectory(root: string): Array<[string, string]> {
+  const snapshot: Array<[string, string]> = [];
+  const visit = (directory: string) => {
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+      const absolute = path.join(directory, entry.name);
+      const relative = path.relative(root, absolute).replace(/\\/g, '/');
+      if (entry.isDirectory()) {
+        snapshot.push([`${relative}/`, 'directory']);
+        visit(absolute);
+      } else {
+        snapshot.push([relative, fs.readFileSync(absolute).toString('hex')]);
+      }
+    }
+  };
+  visit(root);
+  return snapshot;
+}

--- a/tests/catscompany-skillhub-rpc.test.ts
+++ b/tests/catscompany-skillhub-rpc.test.ts
@@ -16,7 +16,10 @@ import {
   shareLocalSkillForCatsCo,
   validateSkillHubShareMetadata,
 } from '../src/skillhub/local-share';
-import { scanBotSkillWorkspace } from '../src/bot-skills/local-manifest';
+import {
+  BOT_SKILL_LOCAL_MARKER_FILE,
+  scanBotSkillWorkspace,
+} from '../src/bot-skills/local-manifest';
 import { writeBotSkillLocalMarker } from '../src/bot-skills/local-manifest';
 import {
   applySkillHubLocalMetadata,
@@ -109,6 +112,8 @@ describe('CatsCompany SkillHub thin RPC', () => {
   });
 
   test('returns only bounded metadata for the active Bot workspace', async () => {
+    const markerPath = path.join(runtimeRoot, 'skills', 'local-demo', BOT_SKILL_LOCAL_MARKER_FILE);
+    assert.equal(fs.existsSync(markerPath), false);
     const result = await handler.execute(request({
       request_id: 'workspace-1',
       tool_name: SKILLHUB_THIN_RPC_TOOLS.workspace,
@@ -128,6 +133,17 @@ describe('CatsCompany SkillHub thin RPC', () => {
     assert.equal(result.page_limit, 200);
     assert.equal(result.next_offset, null);
     assert.equal(result.truncated, false);
+    assert.equal(fs.existsSync(markerPath), false);
+
+    const repeated = await handler.execute(request({
+      request_id: 'workspace-1-repeat',
+      tool_name: SKILLHUB_THIN_RPC_TOOLS.workspace,
+    }));
+    assert.equal(
+      (repeated.skills as Array<Record<string, unknown>>)[0].local_skill_id,
+      skills[0].local_skill_id,
+    );
+    assert.equal(fs.existsSync(markerPath), false);
   });
 
   test('owner can explicitly sync the reviewed Runtime workspace to the current Agent', async () => {

--- a/tests/cloud-bot-model-apply-retry.test.ts
+++ b/tests/cloud-bot-model-apply-retry.test.ts
@@ -12,6 +12,112 @@ import { createBotDefinitionSyncService } from '../src/bot-definition/service';
 import { BOT_DEFINITION_SCHEMA, type BotDefinition } from '../src/bot-definition/types';
 import { BotSkillBaseStore } from '../src/bot-skills/base-store';
 
+test('post-start BotDefinition updates preserve an operator-managed Skill workspace', async t => {
+  const runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'model-apply-preserved-skills-'));
+  t.after(() => fs.rmSync(runtimeRoot, { recursive: true, force: true }));
+  const configService = createCatsCoLocalConfigService({ runtimeRoot });
+  configService.save({
+    version: 1,
+    endpoints: { httpBaseUrl: 'https://cats.example.test', serverUrl: 'wss://cats.example.test/v0/channels' },
+    account: { token: 'test-owner-token', uid: '7' },
+    currentBot: { uid: '43', apiKey: 'test-bot-key', boundByUserUid: '7', bindingSource: 'test' },
+  });
+  const auth = configService.getAuthState();
+  const definitions = createBotDefinitionSyncService({ runtimeRoot });
+  const previous: BotDefinition = {
+    schema: BOT_DEFINITION_SCHEMA,
+    botId: '43',
+    model: {
+      kind: 'custom',
+      protocol: 'openai-responses',
+      apiBase: 'https://models.example.test/v1',
+      model: 'unchanged-model',
+      apiKey: 'test-model-key',
+      contextWindowTokens: 128000,
+    },
+    prompt: { selected: 'custom', customSystemPrompt: 'Previous prompt.' },
+    skills: [],
+  };
+  definitions.acceptCanonical(previous);
+  const desired: BotDefinition = {
+    ...previous,
+    prompt: { selected: 'custom', customSystemPrompt: 'Updated prompt.' },
+    skills: [{
+      source: 'skillhub',
+      skillId: 'private/cloud-only',
+      version: 'sha256-cloud-only',
+      contentHash: 'a'.repeat(64),
+    }],
+  };
+  const localSkillRoot = path.join(runtimeRoot, 'skills', 'operator-local');
+  const localSkillFile = path.join(localSkillRoot, 'SKILL.md');
+  const localSkillText = [
+    '---',
+    'name: operator-local',
+    'description: Operator-managed local Skill used for preservation testing.',
+    '---',
+    '',
+    'Keep this local content unchanged.',
+    '',
+  ].join('\n');
+  fs.mkdirSync(localSkillRoot, { recursive: true });
+  fs.writeFileSync(localSkillFile, localSkillText);
+  new BotSkillBaseStore(runtimeRoot).write({
+    schema: 'xiaoba.bot-skill-sync-base.v2',
+    botId: '43',
+    definitionRevision: 6,
+    skills: [],
+    updatedAt: new Date().toISOString(),
+  });
+
+  const acks: unknown[] = [];
+  t.mock.method(globalThis, 'fetch', async (input: string | URL | Request, init?: RequestInit) => {
+    const url = new URL(String(input));
+    const method = init?.method || 'GET';
+    if (url.pathname === '/api/bot/definition' && method === 'GET') {
+      return Response.json({ configured: true, revision: 7, definition: desired });
+    }
+    if (url.pathname === '/api/bot/definition/ack' && method === 'POST') {
+      acks.push(JSON.parse(String(init?.body)));
+      return Response.json({ status: 'applied' });
+    }
+    if (url.pathname === '/api/bot/definition/default-prompt') {
+      return Response.json({ status: 'stored' });
+    }
+    throw new Error(`Unexpected test request: ${method} ${url.pathname}`);
+  });
+  const oldBot = { isIdleForRuntimeReload: () => true } as CatsCompanyBot;
+  const result = await applyCloudModelRuntimeSelection({
+    runtimeRoot,
+    env: { XIAOBA_PRESERVE_SKILLS: '1' },
+    botId: '43',
+    auth,
+    selection: {
+      kind: 'custom',
+      modelId: 'unchanged-model',
+      customModel: desired.model,
+      revision: 7,
+      definition: desired,
+    },
+    canApply: () => true,
+    connectorConfig: {
+      serverUrl: 'wss://cats.example.test/v0/channels',
+      apiKey: 'test-bot-key',
+      botUid: '43',
+    },
+    currentBot: () => oldBot,
+    replaceBot: () => assert.fail('prompt-only update must not replace the connector'),
+    scheduleAckRetry: () => assert.fail('ACK should succeed'),
+    clearAckRetry: () => {},
+  });
+
+  assert.equal(result, 'applied');
+  assert.deepEqual(acks, [{ revision: 7 }]);
+  assert.equal(fs.readFileSync(localSkillFile, 'utf8'), localSkillText);
+  assert.deepEqual(fs.readdirSync(localSkillRoot), ['SKILL.md']);
+  assert.deepEqual(definitions.read('43')?.prompt, desired.prompt);
+});
+
 for (const failure of [502, 503, 504, 429, 'timeout', 'reset', 'shutdown'] as const) {
 for (const failureRead of [3, 4]) {
 test(`cloud recheck ${failure} at read ${failureRead} preserves the old connector`, async t => {


### PR DESCRIPTION
## 背景

部分服务器 Runtime 由运维人员维护一份已有、规模较大的 Skill 工作区。更新到最新 `main` 时，启动阶段的默认 SkillHub bootstrap 或 BotDefinition Skill 准备流程不应自动改写、替换或清理这份工作区。

本 PR 为这类部署提供显式的 `XIAOBA_PRESERVE_SKILLS=1` 保护模式。该模式默认关闭，因此普通安装的现有行为不变。

## 变更

- 保护模式下跳过默认 SkillHub bootstrap。
- 保护模式下，启动、连接和重启连接器时仍准备 BotDefinition/模型配置，但不执行 Skill 工作区 reconcile。
- 在任何好友关系、本地 Bot 绑定或连接器生命周期副作用之前，校验现有 Skill 工作区确实属于目标 Bot；缺失或不匹配时直接失败，不自动接管工作区。
- SkillHub 只读工作区扫描不再为了展示而写入 `.xiaoba-bot-skill.json`。
- 对尚无 marker 的 Skill 使用稳定的确定性本地 ID，使只读选择与后续显式发布/删除操作仍能定位同一 Skill。
- Owner 明确发起的发布、删除和“同步到当前 Agent”操作保持可用。

## 安全与兼容边界

- 功能仅由显式环境变量开启，默认行为不变。
- 不改变工具权限、System Prompt、工具注入或模型 schema。
- `server` Runtime 仍不会暴露或执行 Bot switch；本 PR 不引入跨设备/跨 Agent 绑定能力。
- 保护模式只阻止隐式工作区 mutation，不阻止 Owner 明确发起的 SkillHub mutation。

## 验证

- `npm run build`：通过。
- `npm run test:skillhub-phase1`：286 passed，0 failed，3 skipped（Windows symlink 条件不满足）。
- preservation、SkillHub thin RPC、Bot switch guard 定向测试：51 passed，0 failed。
- 完整 `npm run test:runtime` 的两个失败已在同一 commit 的干净 `main` 上复现：一项需要先构建隔离基线目录，另一项因当前 Windows 环境缺少 `jq`；均非本 PR 引入。

## 部署建议

合并后先制作独立候选 release，在 Fermi 服务器旁路构建并执行验收；不要在当前脏工作目录中直接 `git pull`。确认 Skill 数量、工作区归属、BotDefinition 和聊天能力均正常后，再通过 systemd 原子切换并保留回滚路径。
