### PR TITLE
chore(release): bump version to v1.5.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xiaoba-cli",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xiaoba-cli",
-      "version": "1.5.5",
+      "version": "1.5.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.27.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xiaoba-cli",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "description": "CatsCo - local agent runtime and dashboard",
   "main": "electron/main.js",
   "bin": {


### PR DESCRIPTION
Bump the checked-in application version from 1.5.5 to 1.5.6 in package.json and both root version entries in package-lock.json, preparing the next stable release from current main.

Validation: `node scripts/verify-release-version.js v1.5.6`, `npm run release:check`, and `git diff --check` passed. This PR changes version metadata only; the v1.5.6 tag and release have not been created.
