### PR TITLE
fix: calibrate checkpoint compaction at 85 percent

### DIFF
--- a/src/core/agent-session.ts
+++ b/src/core/agent-session.ts
@@ -65,6 +65,7 @@ import { collectRemoteContextWatermarks } from './remote-context-watermarks';
 import {
   CheckpointCompactionCoordinator,
   CheckpointPersistenceError,
+  resolveCheckpointInputLimitTokens,
   type CheckpointCompactionPhase,
   isCheckpointCompactionEnabled,
 } from './checkpoint-compaction';
@@ -238,8 +239,15 @@ export class AgentSession {
       ? (services.aiService as any).getConfig()
       : {};
     const contextWindow = resolveModelContextWindow(modelConfig);
+    const checkpointInputLimit = resolveCheckpointInputLimitTokens(
+      contextWindow.contextWindowTokens,
+      contextWindow.promptBudgetTokens,
+      contextWindow.maxOutputTokens,
+    );
     Logger.info(
-      `[${key}] 模型上下文: ${contextWindow.label} window=${contextWindow.contextWindowTokens}, promptBudget=${contextWindow.promptBudgetTokens}, reserve=${contextWindow.safetyReserveTokens}`,
+      `[${key}] 模型上下文: ${contextWindow.label} window=${contextWindow.contextWindowTokens}, `
+      + `checkpointLimit=${checkpointInputLimit}, promptBudget=${contextWindow.promptBudgetTokens}, `
+      + `reserve=${contextWindow.safetyReserveTokens}`,
     );
     this.contextWindowManager = new ContextWindowManager(services.aiService, {
       maxContextTokens: contextWindow.promptBudgetTokens,
@@ -247,7 +255,10 @@ export class AgentSession {
     });
     this.checkpointCompactionCoordinator = new CheckpointCompactionCoordinator(
       services.aiService,
-      { maxContextTokens: contextWindow.promptBudgetTokens },
+      {
+        maxContextTokens: contextWindow.contextWindowTokens,
+        compactionTriggerTokens: checkpointInputLimit,
+      },
     );
     this.useCheckpointCompaction = isCheckpointCompactionEnabled();
     this.skillRuntime = new SessionSkillRuntime(services.skillManager, key);
@@ -273,6 +284,9 @@ export class AgentSession {
       workspaceRoot: this.defaultDirectory,
       getCurrentDirectory: () => this.currentDirectory,
       updateCurrentDirectory: directory => this.updateCurrentDirectory(directory),
+      maxPromptTokens: this.useCheckpointCompaction
+        ? checkpointInputLimit
+        : contextWindow.promptBudgetTokens,
       checkpointCompactionCoordinator: this.useCheckpointCompaction
         ? this.checkpointCompactionCoordinator
         : undefined,

--- a/src/core/agent-turn-controller.ts
+++ b/src/core/agent-turn-controller.ts
@@ -117,6 +117,7 @@ export interface AgentTurnControllerOptions {
   workspaceRoot: string;
   getCurrentDirectory: () => string;
   updateCurrentDirectory: (directory: string) => void;
+  maxPromptTokens?: number;
   checkpointCompactionCoordinator?: CheckpointCompactionCoordinator;
   persistCheckpoint?: (messages: Message[]) => void | Promise<void>;
 }
@@ -360,6 +361,7 @@ export class AgentTurnController {
         pendingUserInputProvider: options.pendingUserInputProvider,
         syntheticObservationProvider: options.syntheticObservationProvider,
         episodeId: options.episodeId,
+        maxContextTokens: this.options.maxPromptTokens,
         checkpointCompactionCoordinator: this.options.checkpointCompactionCoordinator,
         onCompactionCheckpoint: this.options.persistCheckpoint,
         // AgentSession/ContextWindowManager compacts durable history before the turn.

--- a/src/core/checkpoint-compaction.ts
+++ b/src/core/checkpoint-compaction.ts
@@ -14,7 +14,8 @@ export const CHECKPOINT_SUMMARY_PREFIX = [
   'Use this summary to continue the same task without repeating completed work:',
 ].join(' ');
 
-const DEFAULT_COMPACTION_THRESHOLD = 0.8;
+export const DEFAULT_CHECKPOINT_COMPACTION_THRESHOLD = 0.85;
+export const MIN_PHYSICAL_WINDOW_CHECKPOINT_TOKENS = 256_000;
 const MIN_RETAINED_USER_TOKEN_BUDGET = 8_000;
 const MAX_RETAINED_USER_TOKEN_BUDGET = 32_000;
 const RETAINED_USER_CONTEXT_RATIO = 0.15;
@@ -32,6 +33,7 @@ export type CheckpointCompactionPhase = 'pre_turn' | 'mid_turn' | 'restore';
 export interface CheckpointCompactionCoordinatorOptions {
   maxContextTokens: number;
   compactionThreshold?: number;
+  compactionTriggerTokens?: number;
   retainedUserTokenBudget?: number;
 }
 
@@ -40,6 +42,7 @@ export interface CheckpointCompactionRequest {
   phase: CheckpointCompactionPhase;
   episodeId?: string;
   toolTokens?: number;
+  promptOverheadTokens?: number;
   signal?: AbortSignal;
   onStatus?: (event: CheckpointCompactionStatusEvent) => void | Promise<void>;
 }
@@ -65,6 +68,12 @@ export interface CheckpointCompactionResult {
   usagePercent: number;
 }
 
+interface ProviderPromptUsageAnchor {
+  positiveCorrectionTokens: number;
+  durableMessageCount: number;
+  durablePrefixHash: string;
+}
+
 export class CheckpointPersistenceError extends Error {
   constructor(cause?: unknown) {
     super('Continuation checkpoint could not be persisted; the current turn was stopped before another model request.');
@@ -88,6 +97,42 @@ export function isCheckpointCompactionEnabled(
   return env.XIAOBA_CHECKPOINT_COMPACTION_ENABLED !== 'false';
 }
 
+export function calculateCheckpointInputLimitTokens(
+  contextWindowTokens: number,
+  threshold = DEFAULT_CHECKPOINT_COMPACTION_THRESHOLD,
+): number {
+  const safeWindow = Math.max(1, Math.floor(contextWindowTokens));
+  const ratio = readRatio(threshold, DEFAULT_CHECKPOINT_COMPACTION_THRESHOLD);
+  return Math.max(1, Math.floor(safeWindow * ratio));
+}
+
+/**
+ * The physical-window 85% policy is intentionally scoped to 256K+ models
+ * whose configured output fits in the remaining 15%. Smaller windows and
+ * unusually high-output configurations keep the legacy prompt budget so
+ * checkpoint compaction cannot remove their output headroom.
+ */
+export function resolveCheckpointInputLimitTokens(
+  contextWindowTokens: number,
+  legacyPromptBudgetTokens: number,
+  maxOutputTokens = 0,
+  threshold = DEFAULT_CHECKPOINT_COMPACTION_THRESHOLD,
+): number {
+  const safeWindow = Math.max(1, Math.floor(contextWindowTokens));
+  const physicalWindowLimit = calculateCheckpointInputLimitTokens(safeWindow, threshold);
+  const safeMaxOutput = Math.max(0, Math.floor(maxOutputTokens));
+  if (
+    safeWindow < MIN_PHYSICAL_WINDOW_CHECKPOINT_TOKENS
+    || physicalWindowLimit + safeMaxOutput > safeWindow
+  ) {
+    return Math.min(
+      safeWindow,
+      Math.max(1, Math.floor(legacyPromptBudgetTokens)),
+    );
+  }
+  return physicalWindowLimit;
+}
+
 /**
  * Codex-style continuation compaction for the main Agent.
  *
@@ -99,8 +144,10 @@ export function isCheckpointCompactionEnabled(
 export class CheckpointCompactionCoordinator {
   private readonly maxContextTokens: number;
   private readonly compactionThreshold: number;
+  private readonly compactionTriggerTokens: number;
   private readonly retainedUserTokenBudget: number;
   private lastUnproductiveSource?: string;
+  private providerUsageAnchor?: ProviderPromptUsageAnchor;
 
   constructor(
     private readonly aiService: AIService,
@@ -109,7 +156,17 @@ export class CheckpointCompactionCoordinator {
     this.maxContextTokens = Math.max(1, Math.floor(options.maxContextTokens));
     this.compactionThreshold = readRatio(
       options.compactionThreshold,
-      DEFAULT_COMPACTION_THRESHOLD,
+      DEFAULT_CHECKPOINT_COMPACTION_THRESHOLD,
+    );
+    this.compactionTriggerTokens = Math.min(
+      this.maxContextTokens,
+      Math.max(
+        1,
+        Math.floor(
+          options.compactionTriggerTokens
+          ?? this.maxContextTokens * this.compactionThreshold,
+        ),
+      ),
     );
     this.retainedUserTokenBudget = Math.max(
       256,
@@ -123,14 +180,66 @@ export class CheckpointCompactionCoordinator {
     );
   }
 
-  getUsageInfo(messages: Message[], toolTokens = 0): {
+  /**
+   * Calibrates local durable-context estimates from the provider's accounting
+   * for the exact request. One-shot transient hints are subtracted through the
+   * local request estimate instead of becoming permanent transcript weight.
+   *
+   * The durable prefix hash prevents a calibration from surviving compaction,
+   * restore, trimming, or any other non-append transcript mutation.
+   */
+  observeProviderPromptUsage(
+    promptTokens: number | undefined,
+    messagesAtRequest: Message[],
+    providerMessagesAtRequest: Message[],
+    toolTokens = 0,
+  ): void {
+    if (!Number.isFinite(promptTokens) || Number(promptTokens) <= 0) return;
+    if (Number(promptTokens) > this.maxContextTokens) {
+      this.providerUsageAnchor = undefined;
+      Logger.warning(
+        `[checkpoint] ignored impossible provider prompt usage: ${Math.floor(Number(promptTokens))}`
+        + ` > context window ${this.maxContextTokens}`,
+      );
+      return;
+    }
+    const durable = splitDurableAndTransient(messagesAtRequest).durable;
+    const localProviderTokens = estimateMessagesTokens(providerMessagesAtRequest)
+      + Math.max(0, Math.floor(toolTokens));
+    const positiveCorrectionTokens = Math.max(
+      0,
+      Math.floor(Number(promptTokens)) - localProviderTokens,
+    );
+    this.providerUsageAnchor = {
+      positiveCorrectionTokens,
+      durableMessageCount: durable.length,
+      durablePrefixHash: hashMessages(durable),
+    };
+  }
+
+  getUsageInfo(messages: Message[], toolTokens = 0, promptOverheadTokens = 0): {
     usedTokens: number;
     toolTokens: number;
     maxTokens: number;
     usagePercent: number;
   } {
-    const usedTokens = estimateMessagesTokens(splitDurableAndTransient(messages).durable);
+    const durable = splitDurableAndTransient(messages).durable;
+    const safePromptOverheadTokens = Math.max(0, Math.floor(promptOverheadTokens));
+    const localUsedTokens = estimateMessagesTokens(durable) + safePromptOverheadTokens;
     const safeToolTokens = Math.max(0, Math.floor(toolTokens));
+    const localTotalTokens = localUsedTokens + safeToolTokens;
+    const anchoredTotalTokens = this.getAnchoredTotalTokens(
+      durable,
+      safeToolTokens,
+      safePromptOverheadTokens,
+    );
+    // A malformed or incomplete upstream usage value must never reduce the
+    // local safety estimate. A valid higher value corrects tokenizer drift and
+    // also carries forward provider-visible prompt overhead.
+    const totalTokens = anchoredTotalTokens === undefined
+      ? localTotalTokens
+      : Math.max(localTotalTokens, anchoredTotalTokens);
+    const usedTokens = Math.max(0, totalTokens - safeToolTokens);
     return {
       usedTokens,
       toolTokens: safeToolTokens,
@@ -139,10 +248,28 @@ export class CheckpointCompactionCoordinator {
     };
   }
 
-  needsCompaction(messages: Message[], toolTokens = 0): boolean {
-    const usage = this.getUsageInfo(messages, toolTokens);
+  private getAnchoredTotalTokens(
+    durable: Message[],
+    toolTokens: number,
+    promptOverheadTokens: number,
+  ): number | undefined {
+    const anchor = this.providerUsageAnchor;
+    if (!anchor || durable.length < anchor.durableMessageCount) return undefined;
+    const currentPrefix = durable.slice(0, anchor.durableMessageCount);
+    if (hashMessages(currentPrefix) !== anchor.durablePrefixHash) return undefined;
+    return Math.max(
+      0,
+      estimateMessagesTokens(durable)
+        + promptOverheadTokens
+        + toolTokens
+        + anchor.positiveCorrectionTokens,
+    );
+  }
+
+  needsCompaction(messages: Message[], toolTokens = 0, promptOverheadTokens = 0): boolean {
+    const usage = this.getUsageInfo(messages, toolTokens, promptOverheadTokens);
     return usage.usedTokens + usage.toolTokens
-      > this.maxContextTokens * this.compactionThreshold;
+      > this.compactionTriggerTokens;
   }
 
   async compactIfNeeded(
@@ -150,8 +277,16 @@ export class CheckpointCompactionCoordinator {
     request: CheckpointCompactionRequest,
   ): Promise<CheckpointCompactionResult> {
     request.signal?.throwIfAborted();
-    const usage = this.getUsageInfo(messages, request.toolTokens);
-    if (!this.needsCompaction(messages, request.toolTokens)) {
+    const usage = this.getUsageInfo(
+      messages,
+      request.toolTokens,
+      request.promptOverheadTokens,
+    );
+    if (!this.needsCompaction(
+      messages,
+      request.toolTokens,
+      request.promptOverheadTokens,
+    )) {
       return { messages, compacted: false, ...usage };
     }
 
@@ -171,13 +306,17 @@ export class CheckpointCompactionCoordinator {
         return { messages, compacted: false, ...usage };
       }
       request.signal?.throwIfAborted();
-      if (estimateMessagesTokens(splitDurableAndTransient(result).durable) >= usage.usedTokens) {
+      const sourceDurableTokens = estimateMessagesTokens(
+        splitDurableAndTransient(messages).durable,
+      );
+      if (estimateMessagesTokens(splitDurableAndTransient(result).durable) >= sourceDurableTokens) {
         this.lastUnproductiveSource = sourceKey;
         await this.emitStatus(request, { status: 'skipped', sessionKey: request.sessionKey, phase: request.phase, ...usage });
         Logger.info(`[${request.sessionKey}] checkpoint did not reduce context; keeping the original transcript`);
         return { messages, compacted: false, ...usage };
       }
       this.lastUnproductiveSource = undefined;
+      this.providerUsageAnchor = undefined;
       await this.emitStatus(request, {
         status: 'complete',
         sessionKey: request.sessionKey,
@@ -857,4 +996,8 @@ function readRatio(value: number | undefined, fallback: number): number {
 
 function describeError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+function hashMessages(messages: Message[]): string {
+  return createHash('sha256').update(JSON.stringify(messages)).digest('hex');
 }

--- a/src/core/conversation-runner.ts
+++ b/src/core/conversation-runner.ts
@@ -11,6 +11,7 @@ import { Metrics } from '../utils/metrics';
 import { ContextCompressor } from './context-compressor';
 import {
   CheckpointPersistenceError,
+  splitDurableAndTransient,
   type CheckpointCompactionCoordinator,
 } from './checkpoint-compaction';
 import { estimateMessagesTokens, estimateToolsTokens } from './token-estimator';
@@ -412,16 +413,46 @@ export class ConversationRunner {
       const perTurnRunnerHint = transientPolicy.injectRunnerHint
         ? buildPerTurnRunnerHint(requestTools)
         : null;
-      let requestMessages = this.buildProviderInputMessages(messages, [
+      const providerTransientHints = [
         ...runtimeTransientHints,
         ...(perTurnRunnerHint ? [perTurnRunnerHint] : []),
         ...nextTurnTransientHints,
         ...orchestrationHints,
-      ], {
+      ];
+      let requestMessages = this.buildProviderInputMessages(messages, providerTransientHints, {
         includeCurrentDirectoryHint: transientPolicy.injectEnvironment,
         currentDirectory,
       });
       nextTurnTransientHints = [];
+      const promptOverheadTokens = estimateMessagesTokens(
+        splitDurableAndTransient(requestMessages).transient,
+      );
+      const needsPromptOverheadCompaction = this.checkpointCompactionCoordinator
+        ?.needsCompaction;
+      if (
+        promptOverheadTokens > 0
+        && typeof needsPromptOverheadCompaction === 'function'
+        && needsPromptOverheadCompaction.call(
+          this.checkpointCompactionCoordinator,
+          messages,
+          estimateToolsTokens(requestTools),
+          promptOverheadTokens,
+        )
+      ) {
+        const compactedForPromptOverhead = await this.compactMidTurnIfNeeded(
+          messages,
+          requestTools,
+          turns,
+          callbacks,
+          promptOverheadTokens,
+        );
+        if (compactedForPromptOverhead) {
+          requestMessages = this.buildProviderInputMessages(messages, providerTransientHints, {
+            includeCurrentDirectoryHint: transientPolicy.injectEnvironment,
+            currentDirectory,
+          });
+        }
+      }
       const promptTrimmed = this.ensurePromptBudget(requestMessages, requestTools);
       if (promptTrimmed && callbacks?.onThinking) {
         await callbacks.onThinking(PROMPT_BUDGET_TRIM_MESSAGE);
@@ -484,6 +515,17 @@ export class ConversationRunner {
       if (response.usage) {
         Metrics.recordAICall(this.stream ? 'stream' : 'chat', response.usage);
         Logger.info(`[${this.sessionLabel}Turn ${turns}] AI返回 tokens: ${response.usage.promptTokens}+${response.usage.completionTokens}=${response.usage.totalTokens}`);
+        const observeProviderPromptUsage = this.checkpointCompactionCoordinator
+          ?.observeProviderPromptUsage;
+        if (typeof observeProviderPromptUsage === 'function') {
+          observeProviderPromptUsage.call(
+            this.checkpointCompactionCoordinator,
+            response.usage.promptTokens,
+            messages,
+            requestMessages,
+            estimateToolsTokens(requestTools),
+          );
+        }
       }
 
       if ((!response.toolCalls || response.toolCalls.length === 0) && response.content) {
@@ -827,13 +869,15 @@ export class ConversationRunner {
     tools: ToolDefinition[],
     turns: number,
     callbacks?: RunnerCallbacks,
-  ): Promise<void> {
-    if (!this.checkpointCompactionCoordinator) return;
+    promptOverheadTokens = 0,
+  ): Promise<boolean> {
+    if (!this.checkpointCompactionCoordinator) return false;
     const result = await this.checkpointCompactionCoordinator.compactIfNeeded(messages, {
       sessionKey: this.toolExecutionContext?.sessionId || this.sessionLabel.trim() || 'runner',
       phase: 'mid_turn',
       episodeId: this.episodeId,
       toolTokens: estimateToolsTokens(tools),
+      promptOverheadTokens,
       signal: this.toolExecutionContext?.abortSignal,
       onStatus: callbacks?.onThinking
         ? async event => {
@@ -849,7 +893,7 @@ export class ConversationRunner {
         }
         : undefined,
     });
-    if (!result.compacted) return;
+    if (!result.compacted) return false;
     this.toolExecutionContext?.abortSignal?.throwIfAborted();
 
     try {
@@ -877,6 +921,7 @@ export class ConversationRunner {
     Logger.info(
       `[${this.sessionLabel}Turn ${turns}] durable mid-turn checkpoint persisted; continuing same episode`,
     );
+    return true;
   }
 
   private refreshRuntimeContextForPendingInput(messages: Message[]): void {

--- a/tests/checkpoint-compaction-256k-scenario.test.ts
+++ b/tests/checkpoint-compaction-256k-scenario.test.ts
@@ -6,10 +6,8 @@ import {
   CheckpointCompactionCoordinator,
 } from '../src/core/checkpoint-compaction';
 import { estimateMessagesTokens } from '../src/core/token-estimator';
-import { calculatePromptBudgetTokens } from '../src/utils/model-context-window';
 
 const CONTEXT_WINDOW_TOKENS = 256_000;
-const MAX_OUTPUT_TOKENS = 32_768;
 const TOOL_SCHEMA_TOKENS = 8_000;
 const SUMMARY_TOKENS = 4_000;
 
@@ -46,36 +44,32 @@ function createSummaryService(requests: Message[][]): any {
 
 function createCoordinator(requests: Message[][]): {
   coordinator: CheckpointCompactionCoordinator;
-  promptBudgetTokens: number;
+  contextWindowTokens: number;
   triggerTokens: number;
 } {
-  const budget = calculatePromptBudgetTokens(
-    CONTEXT_WINDOW_TOKENS,
-    MAX_OUTPUT_TOKENS,
-  );
   return {
     coordinator: new CheckpointCompactionCoordinator(
       createSummaryService(requests),
-      { maxContextTokens: budget.promptBudgetTokens },
+      { maxContextTokens: CONTEXT_WINDOW_TOKENS },
     ),
-    promptBudgetTokens: budget.promptBudgetTokens,
-    triggerTokens: Math.floor(budget.promptBudgetTokens * 0.8) + 1,
+    contextWindowTokens: CONTEXT_WINDOW_TOKENS,
+    triggerTokens: Math.floor(CONTEXT_WINDOW_TOKENS * 0.85) + 1,
   };
 }
 
 test('256K pre-turn scenario compacts old completed history and restores large headroom', async () => {
   const requests: Message[][] = [];
-  const { coordinator, promptBudgetTokens, triggerTokens } = createCoordinator(requests);
+  const { coordinator, contextWindowTokens, triggerTokens } = createCoordinator(requests);
   const messages: Message[] = [
     { role: 'system', content: englishText(8_000, 'Stable system prompt.\n') },
-    { role: 'user', content: englishText(78_000, 'Old objective.\n'), __episodeId: 'old-1' },
-    { role: 'assistant', content: englishText(66_000, 'Old completed work.\n'), __episodeId: 'old-1' },
+    { role: 'user', content: englishText(110_000, 'Old objective.\n'), __episodeId: 'old-1' },
+    { role: 'assistant', content: englishText(95_000, 'Old completed work.\n'), __episodeId: 'old-1' },
     { role: 'user', content: englishText(4_000, 'Most recent user correction.\n'), __episodeId: 'old-2' },
   ];
   const beforeTokens = estimateMessagesTokens(messages) + TOOL_SCHEMA_TOKENS;
 
-  assert.equal(promptBudgetTokens, 203_776);
-  assert.equal(triggerTokens, 163_021);
+  assert.equal(contextWindowTokens, 256_000);
+  assert.equal(triggerTokens, 217_601);
   assert.ok(beforeTokens >= triggerTokens);
 
   const result = await coordinator.compactIfNeeded(messages, {
@@ -86,7 +80,7 @@ test('256K pre-turn scenario compacts old completed history and restores large h
   const afterTokens = estimateMessagesTokens(result.messages) + TOOL_SCHEMA_TOKENS;
 
   assert.equal(result.compacted, true);
-  assert.ok(afterTokens < promptBudgetTokens * 0.25);
+  assert.ok(afterTokens < contextWindowTokens * 0.25);
   assert.ok(result.messages.some(message =>
     String(message.content).includes('Most recent user correction.')));
   assert.equal(result.messages.some(message =>
@@ -97,11 +91,11 @@ test('256K pre-turn scenario compacts old completed history and restores large h
 
 test('256K mid-turn scenario waits for tool completion and keeps the active request', async () => {
   const requests: Message[][] = [];
-  const { coordinator, promptBudgetTokens, triggerTokens } = createCoordinator(requests);
+  const { coordinator, contextWindowTokens, triggerTokens } = createCoordinator(requests);
   const messages: Message[] = [
     { role: 'system', content: englishText(8_000, 'Stable system prompt.\n') },
-    { role: 'user', content: englishText(66_000, 'Earlier history.\n'), __episodeId: 'old-1' },
-    { role: 'assistant', content: englishText(58_000, 'Earlier answer.\n'), __episodeId: 'old-1' },
+    { role: 'user', content: englishText(95_000, 'Earlier history.\n'), __episodeId: 'old-1' },
+    { role: 'assistant', content: englishText(85_000, 'Earlier answer.\n'), __episodeId: 'old-1' },
     {
       role: 'user',
       content: englishText(3_000, 'Active long-task objective.\n'),
@@ -138,7 +132,7 @@ test('256K mid-turn scenario waits for tool completion and keeps the active requ
   const afterTokens = estimateMessagesTokens(result.messages) + TOOL_SCHEMA_TOKENS;
 
   assert.equal(result.compacted, true);
-  assert.ok(afterTokens < promptBudgetTokens * 0.25);
+  assert.ok(afterTokens < contextWindowTokens * 0.25);
   assert.ok(result.messages.some(message =>
     String(message.content).includes('Active long-task objective.')));
   assert.equal(result.messages.some(message => message.role === 'tool'), true);
@@ -148,11 +142,11 @@ test('256K mid-turn scenario waits for tool completion and keeps the active requ
 
 test('256K restore scenario creates a checkpoint that requires runtime re-verification', async () => {
   const requests: Message[][] = [];
-  const { coordinator, promptBudgetTokens, triggerTokens } = createCoordinator(requests);
+  const { coordinator, contextWindowTokens, triggerTokens } = createCoordinator(requests);
   const messages: Message[] = [
     { role: 'system', content: englishText(8_000, 'Stable system prompt.\n') },
-    { role: 'user', content: englishText(80_000, 'Restored historical request.\n') },
-    { role: 'assistant', content: englishText(72_000, 'Restored visible answer.\n') },
+    { role: 'user', content: englishText(110_000, 'Restored historical request.\n') },
+    { role: 'assistant', content: englishText(100_000, 'Restored visible answer.\n') },
   ];
   const beforeTokens = estimateMessagesTokens(messages) + TOOL_SCHEMA_TOKENS;
 
@@ -167,7 +161,7 @@ test('256K restore scenario creates a checkpoint that requires runtime re-verifi
   const checkpointPrompt = String(requests[0][0]?.content || '');
 
   assert.equal(result.compacted, true);
-  assert.ok(afterTokens < promptBudgetTokens * 0.2);
+  assert.ok(afterTokens < contextWindowTokens * 0.2);
   assert.match(checkpointPrompt, /unknown until reverified/i);
   assert.match(checkpointPrompt, /processes, ports, files, devices/i);
 });

--- a/tests/checkpoint-compaction.test.ts
+++ b/tests/checkpoint-compaction.test.ts
@@ -6,8 +6,11 @@ import {
   CHECKPOINT_SUMMARY_PREFIX,
   CheckpointCompactionCoordinator,
   buildCheckpointCompactionPrompt,
+  calculateCheckpointInputLimitTokens,
   isCheckpointCompactionEnabled,
+  resolveCheckpointInputLimitTokens,
 } from '../src/core/checkpoint-compaction';
+import { resolveModelContextWindow } from '../src/utils/model-context-window';
 
 const usage = { promptTokens: 10, completionTokens: 5, totalTokens: 15 };
 
@@ -42,6 +45,156 @@ test('checkpoint compaction switch defaults on and supports explicit rollback', 
   assert.equal(isCheckpointCompactionEnabled({
     XIAOBA_CHECKPOINT_COMPACTION_ENABLED: 'false',
   } as NodeJS.ProcessEnv), false);
+});
+
+test('default checkpoint threshold is 85 percent of the physical context window', () => {
+  const { service } = createService(() => 'unused summary');
+  const coordinator = new CheckpointCompactionCoordinator(service, {
+    maxContextTokens: 1_000,
+  });
+  const below: Message[] = [{ role: 'user', content: 'x'.repeat(3_300) }];
+  const above: Message[] = [{ role: 'user', content: 'x'.repeat(3_500) }];
+
+  assert.equal(coordinator.needsCompaction(below), false);
+  assert.equal(coordinator.needsCompaction(above), true);
+});
+
+test('checkpoint input limit is 85 percent for supported 256K+ windows', () => {
+  assert.equal(calculateCheckpointInputLimitTokens(256_000), 217_600);
+  assert.equal(calculateCheckpointInputLimitTokens(1_000_000), 850_000);
+});
+
+test('checkpoint input limit preserves the legacy prompt budget below 256K', () => {
+  const minimaxM27 = resolveModelContextWindow(
+    { model: 'MiniMax-M2.7', provider: 'anthropic' },
+    { CATSCO_MODEL_SOURCE: 'relay' } as NodeJS.ProcessEnv,
+  );
+  const custom128K = resolveModelContextWindow({
+    model: 'custom-128k',
+    provider: 'openai',
+    contextWindowTokens: 128_000,
+    maxTokens: 32_000,
+  });
+
+  for (const resolution of [minimaxM27, custom128K]) {
+    const inputLimit = resolveCheckpointInputLimitTokens(
+      resolution.contextWindowTokens,
+      resolution.promptBudgetTokens,
+      resolution.maxOutputTokens,
+    );
+    assert.equal(inputLimit, resolution.promptBudgetTokens);
+    assert.ok(
+      inputLimit + resolution.maxOutputTokens <= resolution.contextWindowTokens,
+      `${resolution.label} request budget must fit the physical context window`,
+    );
+  }
+
+  assert.equal(minimaxM27.contextWindowTokens, 204_800);
+  assert.equal(minimaxM27.promptBudgetTokens, 155_648);
+  assert.equal(custom128K.promptBudgetTokens, 84_224);
+});
+
+test('checkpoint input limit preserves output headroom for a 256K high-output model', () => {
+  const highOutput256K = resolveModelContextWindow({
+    model: 'custom-256k',
+    provider: 'openai',
+    contextWindowTokens: 256_000,
+    maxTokens: 64_000,
+  });
+  const inputLimit = resolveCheckpointInputLimitTokens(
+    highOutput256K.contextWindowTokens,
+    highOutput256K.promptBudgetTokens,
+    highOutput256K.maxOutputTokens,
+  );
+
+  assert.equal(inputLimit, highOutput256K.promptBudgetTokens);
+  assert.equal(inputLimit, 172_544);
+  assert.ok(inputLimit + highOutput256K.maxOutputTokens <= 256_000);
+});
+
+test('provider prompt usage anchors locally estimated appended messages and tools', () => {
+  const { service } = createService(() => 'unused summary');
+  const coordinator = new CheckpointCompactionCoordinator(service, {
+    maxContextTokens: 1_000,
+  });
+  const atRequest: Message[] = [{ role: 'user', content: 'small request' }];
+  coordinator.observeProviderPromptUsage(800, atRequest, atRequest, 20);
+
+  const current: Message[] = [
+    ...atRequest,
+    { role: 'assistant', content: 'x'.repeat(240) },
+  ];
+  const usageInfo = coordinator.getUsageInfo(current, 20);
+
+  assert.equal(usageInfo.usedTokens + usageInfo.toolTokens, 864);
+  assert.equal(coordinator.needsCompaction(current, 20), true);
+});
+
+test('provider usage cannot lower the local safety estimate and is ignored after prefix mutation', () => {
+  const { service } = createService(() => 'unused summary');
+  const coordinator = new CheckpointCompactionCoordinator(service, {
+    maxContextTokens: 1_000,
+  });
+  const large: Message[] = [{ role: 'user', content: 'x'.repeat(3_500) }];
+  coordinator.observeProviderPromptUsage(10, large, large);
+  assert.equal(coordinator.needsCompaction(large), true);
+
+  const small: Message[] = [{ role: 'user', content: 'small request' }];
+  coordinator.observeProviderPromptUsage(900, small, small);
+  const replaced: Message[] = [{ role: 'user', content: 'different request' }];
+  assert.equal(coordinator.needsCompaction(replaced), false);
+});
+
+test('provider calibration does not retain a one-shot transient prompt as durable usage', () => {
+  const { service } = createService(() => 'unused summary');
+  const coordinator = new CheckpointCompactionCoordinator(service, {
+    maxContextTokens: 1_000,
+  });
+  const durable: Message[] = [{ role: 'user', content: 'small request' }];
+  const providerMessages: Message[] = [
+    ...durable,
+    { role: 'system', content: `[transient_runtime]\n${'x'.repeat(2_800)}` },
+  ];
+  const providerPromptTokens = estimateMessagesTokens(providerMessages) + 20;
+
+  coordinator.observeProviderPromptUsage(
+    providerPromptTokens,
+    durable,
+    providerMessages,
+    20,
+  );
+
+  assert.equal(coordinator.needsCompaction(durable, 20), false);
+  assert.equal(coordinator.needsCompaction(durable, 20, 830), true);
+});
+
+test('impossible provider usage clears the previous calibration', () => {
+  const { service } = createService(() => 'unused summary');
+  const coordinator = new CheckpointCompactionCoordinator(service, {
+    maxContextTokens: 1_000,
+  });
+  const messages: Message[] = [{ role: 'user', content: 'small request' }];
+  coordinator.observeProviderPromptUsage(800, messages, messages);
+  assert.equal(coordinator.getUsageInfo(messages).usedTokens, 800);
+
+  coordinator.observeProviderPromptUsage(1_001, messages, messages);
+  assert.equal(
+    coordinator.getUsageInfo(messages).usedTokens,
+    estimateMessagesTokens(messages),
+  );
+});
+
+test('valid provider usage remains authoritative when local estimation is much lower', () => {
+  const { service } = createService(() => 'unused summary');
+  const coordinator = new CheckpointCompactionCoordinator(service, {
+    maxContextTokens: 100_000,
+  });
+  const messages: Message[] = [{ role: 'user', content: 'x'.repeat(80_000) }];
+  assert.ok(estimateMessagesTokens(messages) < 25_000);
+
+  coordinator.observeProviderPromptUsage(60_000, messages, messages);
+
+  assert.equal(coordinator.getUsageInfo(messages).usedTokens, 60_000);
 });
 
 test('tool-heavy context with only active inputs never calls the summary model repeatedly', async () => {

--- a/tests/conversation-runner-checkpoint-compaction.test.ts
+++ b/tests/conversation-runner-checkpoint-compaction.test.ts
@@ -25,6 +25,96 @@ const unchanged = (messages: Message[]) => ({
   maxTokens: 100, usagePercent: 20,
 });
 
+test('runner reports provider prompt usage to checkpoint accounting', async () => {
+  const observations: Array<{
+    promptTokens: number;
+    messageCount: number;
+    providerMessageCount: number;
+    toolTokens: number;
+  }> = [];
+  const coordinator = {
+    compactIfNeeded: async (messages: Message[]) => unchanged(messages),
+    observeProviderPromptUsage: (
+      promptTokens: number,
+      messages: Message[],
+      providerMessages: Message[],
+      toolTokens: number,
+    ) => {
+      observations.push({
+        promptTokens,
+        messageCount: messages.length,
+        providerMessageCount: providerMessages.length,
+        toolTokens,
+      });
+    },
+  } as any;
+  const tool: ToolDefinition = {
+    name: 'inspect',
+    description: 'inspect',
+    parameters: { type: 'object', properties: {} },
+  };
+  const runner = new ConversationRunner({
+    chat: async () => ({ content: 'done', toolCalls: [], usage: {
+      promptTokens: 777,
+      completionTokens: 5,
+      totalTokens: 782,
+    } }),
+  } as any, {
+    getToolDefinitions: () => [tool],
+    executeTool: async () => { throw new Error('Unexpected tool'); },
+  }, {
+    stream: false,
+    checkpointCompactionCoordinator: coordinator,
+  });
+
+  await runner.run([{ role: 'user', content: 'inspect once' }]);
+
+  assert.equal(observations.length, 1);
+  assert.equal(observations[0].promptTokens, 777);
+  assert.equal(observations[0].messageCount, 1);
+  assert.ok(observations[0].providerMessageCount >= 1);
+  assert.ok(observations[0].toolTokens > 0);
+});
+
+test('runner checkpoints durable history before a large one-shot transient prompt is sent', async () => {
+  const events: string[] = [];
+  const coordinator = new CheckpointCompactionCoordinator({
+    chatStream: async () => {
+      events.push('summary');
+      return { content: 'Earlier work is complete; continue the active request.', usage };
+    },
+  } as any, { maxContextTokens: 1_000 });
+  const runner = new ConversationRunner({
+    chat: async (messages: Message[]) => {
+      events.push('agent');
+      assert.ok(messages.some(message => message.__checkpointSummary));
+      assert.ok(messages.some(message => message.__injected));
+      return { content: 'continued', toolCalls: [], usage };
+    },
+  } as any, {
+    getToolDefinitions: () => [],
+    executeTool: async () => { throw new Error('Unexpected tool'); },
+  }, {
+    stream: false,
+    episodeId: 'active',
+    checkpointCompactionCoordinator: coordinator,
+    onCompactionCheckpoint: async () => { events.push('persist'); },
+  });
+
+  await runner.run([
+    { role: 'user', content: 'x'.repeat(400), __episodeId: 'old' },
+    { role: 'assistant', content: 'x'.repeat(400), __episodeId: 'old' },
+    { role: 'user', content: 'continue', __episodeId: 'active', __episodeInputKind: 'root' },
+    {
+      role: 'system',
+      content: `[transient_runtime]\n${'x'.repeat(2_700)}`,
+      __injected: true,
+    },
+  ]);
+
+  assert.deepEqual(events, ['summary', 'persist', 'agent']);
+});
+
 test('cancellation during a tool rate-limit backoff prevents another execution', { timeout: 5000 }, async () => {
   const controller = new AbortController();
   let executions = 0;

--- a/tests/session-lifecycle-manager.test.ts
+++ b/tests/session-lifecycle-manager.test.ts
@@ -58,6 +58,56 @@ describe('AgentSession lifecycle', () => {
     assert.equal(messages[3].__injected, true);
   });
 
+  test('AgentSession keeps a safe request budget outside the 256K+ 85% policy', () => {
+    const { AgentSession } = loadSessionModules();
+    const cases = [
+      {
+        key: 'user:budget-minimax-m27',
+        config: {
+          model: 'MiniMax-M2.7',
+          provider: 'anthropic',
+          contextWindowTokens: 204_800,
+        },
+        expectedLimit: 155_648,
+      },
+      {
+        key: 'user:budget-custom-128k',
+        config: {
+          model: 'custom-128k',
+          provider: 'openai',
+          contextWindowTokens: 128_000,
+          maxTokens: 32_000,
+        },
+        expectedLimit: 84_224,
+      },
+      {
+        key: 'user:budget-custom-256k-high-output',
+        config: {
+          model: 'custom-256k',
+          provider: 'openai',
+          contextWindowTokens: 256_000,
+          maxTokens: 64_000,
+        },
+        expectedLimit: 172_544,
+      },
+    ];
+
+    for (const item of cases) {
+      const session = new AgentSession(item.key, buildMockServices({
+        aiService: {
+          getConfig() { return item.config; },
+        },
+      }), 'feishu');
+      assert.equal((session as any).turnController.options.maxPromptTokens, item.expectedLimit);
+      assert.equal(
+        (session as any).checkpointCompactionCoordinator.compactionTriggerTokens,
+        item.expectedLimit,
+      );
+      assert.ok(item.expectedLimit + (item.config.maxTokens ?? 32_768)
+        <= item.config.contextWindowTokens);
+    }
+  });
+
   test('reset and clear discard pending restored history before initialization', async () => {
     const { AgentSession, SessionStore } = loadSessionModules();
     SessionStore.getInstance().saveContext('user:lifecycle-reset', [


### PR DESCRIPTION
## 背景

Checkpoint 触发此前先从物理上下文窗口扣除最大输出、协议和估算误差，再对剩余 prompt budget 应用百分比，导致 256K 模型在物理窗口约 64% 时就开始压缩。本 PR 将该边界统一为物理上下文窗口的严格 `>85%`，当前范围明确为 256K 及以上模型。

## 修改

- 以物理 context window 的 85% 作为唯一 Checkpoint 触发线，不再对已扣减的 prompt budget 二次应用阈值。
- 使用 Provider 返回的 prompt usage 作为正向校准锚点，并由本地估算补上此后新增消息、工具定义和当前一次性提示。
- 低于本地估算的 usage 不降低安全水位；超过物理窗口的异常 usage 会使锚点失效。
- 当前请求的一次性提示只参与本次发送前检查，不会污染后续持久上下文；如果它将请求推过阈值，会先完成并原子保存 Checkpoint，再重建请求。
- 保留现有完整 tool call/result 边界、Checkpoint 原子持久化，以及压缩失败后停止当前 turn 的行为。

## 验证

- 两轮独立代码审查和主审查均已收敛，无剩余 P1/P2 问题。
- 定向 Checkpoint / Runner / Session 测试通过（合并并发运行时出现过 Windows 临时目录 `EBUSY`，对应 Session 套件单独复跑 55/55 通过）。
- `npm run build` 通过。
- `npm run release:check` 通过。
- `npm run test:skillhub-phase1`：287 通过，3 跳过，0 失败。
- `npm test`：1,857 项中 1,836 通过，20 跳过；唯一失败是本机 WSL 缺少 `/bin/bash` 的既有 Tianyi 镜像环境测试，与本 PR 文件无关。

## 范围

- 本 PR 不为小于 256K 的模型单独设计输出空间分支。
- 不引入异步 Branch Summary 或 Branch Memory 改动。
