### PR TITLE
Fix SkillHub device identity validation

### DIFF
--- a/src/catscompany/skillhub-rpc.ts
+++ b/src/catscompany/skillhub-rpc.ts
@@ -755,9 +755,11 @@ export class SkillHubThinRpcHandler {
     if (!ownerUid || normalizeUid(request.target_owner_user_id) !== normalizeUid(ownerUid)) {
       throw new SkillHubThinRpcError('OWNER_MISMATCH', 'The local CatsCo account does not match this request.');
     }
-    // Device registration uses installationId first (see CatsCompanyAdapter), so
-    // validate thin RPC requests against the same canonical route identity.
-    const deviceId = String(config.device?.installationId || config.device?.deviceId || '').trim();
+    // Device registration uses installationId first and falls back to bodyId
+    // (see CatsCompanyAdapter). Keep deviceId last for legacy local configs.
+    const deviceId = String(
+      config.device?.installationId || config.device?.bodyId || config.device?.deviceId || '',
+    ).trim();
     const requestDeviceId = String(request.target_device_id || request.device_id || '').trim();
     if (!deviceId || requestDeviceId !== deviceId) {
       throw new SkillHubThinRpcError('DEVICE_MISMATCH', 'The request targets a different XiaoBa device.');

--- a/src/catscompany/skillhub-rpc.ts
+++ b/src/catscompany/skillhub-rpc.ts
@@ -755,7 +755,9 @@ export class SkillHubThinRpcHandler {
     if (!ownerUid || normalizeUid(request.target_owner_user_id) !== normalizeUid(ownerUid)) {
       throw new SkillHubThinRpcError('OWNER_MISMATCH', 'The local CatsCo account does not match this request.');
     }
-    const deviceId = String(config.device?.deviceId || config.device?.installationId || '').trim();
+    // Device registration uses installationId first (see CatsCompanyAdapter), so
+    // validate thin RPC requests against the same canonical route identity.
+    const deviceId = String(config.device?.installationId || config.device?.deviceId || '').trim();
     const requestDeviceId = String(request.target_device_id || request.device_id || '').trim();
     if (!deviceId || requestDeviceId !== deviceId) {
       throw new SkillHubThinRpcError('DEVICE_MISMATCH', 'The request targets a different XiaoBa device.');

--- a/tests/catscompany-skillhub-rpc.test.ts
+++ b/tests/catscompany-skillhub-rpc.test.ts
@@ -863,6 +863,40 @@ describe('CatsCompany SkillHub thin RPC', () => {
     );
   });
 
+  test('accepts the registered installation ID when body and installation identities differ', async () => {
+    createCatsCoLocalConfigService({ runtimeRoot }).save({
+      version: 1,
+      account: { token: 'user-token', uid: '7', username: 'alice' },
+      currentBot: {
+        uid: '42',
+        apiKey: 'bot-key',
+        boundByUserUid: '7',
+      },
+      device: {
+        deviceId: 'alice-body',
+        bodyId: 'alice-body',
+        installationId: 'alice-installation',
+      },
+    });
+
+    const result = await handler.execute(request({
+      request_id: 'installation-device',
+      target_device_id: 'alice-installation',
+      device_id: 'alice-installation',
+    }));
+    assert.equal(result.schema, 'xiaoba.skillhub.local_workspace.v1');
+    assert.equal(result.bot_uid, '42');
+
+    await assert.rejects(
+      handler.execute(request({
+        request_id: 'body-device',
+        target_device_id: 'alice-body',
+        device_id: 'alice-body',
+      })),
+      (error: any) => error instanceof SkillHubThinRpcError && error.code === 'DEVICE_MISMATCH',
+    );
+  });
+
   test('schedules an explicit Bot switch once for a replayed request', async () => {
     const switchRequest = request({
       request_id: 'switch-1',

--- a/tests/catscompany-skillhub-rpc.test.ts
+++ b/tests/catscompany-skillhub-rpc.test.ts
@@ -897,6 +897,40 @@ describe('CatsCompany SkillHub thin RPC', () => {
     );
   });
 
+  test('falls back to the registered body ID when installation identity is absent', async () => {
+    createCatsCoLocalConfigService({ runtimeRoot }).save({
+      version: 1,
+      account: { token: 'user-token', uid: '7', username: 'alice' },
+      currentBot: {
+        uid: '42',
+        apiKey: 'bot-key',
+        boundByUserUid: '7',
+      },
+      device: {
+        deviceId: 'alice-legacy-device',
+        bodyId: 'alice-body',
+        installationId: '',
+      },
+    });
+
+    const result = await handler.execute(request({
+      request_id: 'body-fallback-device',
+      target_device_id: 'alice-body',
+      device_id: 'alice-body',
+    }));
+    assert.equal(result.schema, 'xiaoba.skillhub.local_workspace.v1');
+    assert.equal(result.bot_uid, '42');
+
+    await assert.rejects(
+      handler.execute(request({
+        request_id: 'legacy-device-id',
+        target_device_id: 'alice-legacy-device',
+        device_id: 'alice-legacy-device',
+      })),
+      (error: any) => error instanceof SkillHubThinRpcError && error.code === 'DEVICE_MISMATCH',
+    );
+  });
+
   test('schedules an explicit Bot switch once for a replayed request', async () => {
     const switchRequest = request({
       request_id: 'switch-1',


### PR DESCRIPTION
## Summary
- validate SkillHub thin RPC requests against the installation ID used by CatsCo device registration
- mirror Connector fallback to the registered body ID when an installation ID is absent, while retaining legacy device ID compatibility
- keep device mismatch rejection for non-canonical IDs
- add regressions for runtimes whose identity fields differ and for legacy configs without an installation ID

## Verification
- `node --import tsx --test tests/catscompany-skillhub-rpc.test.ts` (49/49 pass)
- related CatsCo identity tests (40/40 pass)
- `npm run build` passes
- original full runtime suite: 1832 pass, 2 environment-only failures, 17 skipped; failures are an existing Node 24 Windows native crash in bundled knowledge runtime and missing `jq` for the worker updater test

## Production evidence
Jack runs 1.5.6 / 5888fc09. Its Connector registers the installation ID and SkillHub targets that same ID, while the old check preferred the distinct body/device ID and returned DEVICE_MISMATCH.
