### PR TITLE
fix: ignore local Skill virtual environments

### DIFF
--- a/src/bot-skills/local-manifest.ts
+++ b/src/bot-skills/local-manifest.ts
@@ -35,6 +35,7 @@ const EPHEMERAL_DIRECTORIES = new Set([
   '.mypy_cache',
   '.pytest_cache',
   '.ruff_cache',
+  '.venv',
   '__pycache__',
 ]);
 const SKIP_FILES = new Set([

--- a/src/bot-skills/pending-snapshot.ts
+++ b/src/bot-skills/pending-snapshot.ts
@@ -1,6 +1,7 @@
 import * as crypto from 'crypto';
 import * as fs from 'fs';
 import * as path from 'path';
+import { isEphemeralSkillDirectory } from './local-manifest';
 
 export interface BotSkillPendingSnapshotOptions {
   runtimeRoot: string;
@@ -42,9 +43,9 @@ interface PendingSnapshotManifest {
 }
 
 /**
- * Preserves a complete local Skill workspace before Cloud-authoritative
- * activation replaces it. The snapshot is evidence only and is never loaded
- * as an active Skill workspace.
+ * Preserves durable local Skill workspace content before Cloud-authoritative
+ * activation replaces it. Regenerable runtime directories are excluded. The
+ * snapshot is evidence only and is never loaded as an active Skill workspace.
  */
 export function snapshotPendingBotSkillWorkspace(
   options: BotSkillPendingSnapshotOptions,
@@ -120,6 +121,9 @@ function listWorkspaceFiles(root: string): PendingSnapshotFile[] {
   const files: PendingSnapshotFile[] = [];
   const visit = (directory: string): void => {
     for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+      // Only skip real runtime directories. A symlink with an ephemeral name
+      // still reaches lstat below and is rejected fail-closed.
+      if (entry.isDirectory() && isEphemeralSkillDirectory(entry.name)) continue;
       const absolute = path.join(directory, entry.name);
       const relative = path.relative(root, absolute).split(path.sep).join('/');
       const stats = fs.lstatSync(absolute);

--- a/tests/bot-skills-security.test.ts
+++ b/tests/bot-skills-security.test.ts
@@ -88,6 +88,7 @@ describe('Bot Skill sync security boundaries', () => {
       path.join(skillRoot, '.cache', 'quant_cache.db'),
       path.join(skillRoot, '.mypy_cache', 'state.bin'),
       path.join(skillRoot, '.ruff_cache', 'state.bin'),
+      path.join(skillRoot, '.venv', 'lib', 'python', 'site-packages', 'runtime.bin'),
       path.join(skillRoot, '__pycache__', 'module.pyc'),
       path.join(skillRoot, '.pytest_cache', 'state.bin'),
     ];

--- a/tests/bot-skills-sync.test.ts
+++ b/tests/bot-skills-sync.test.ts
@@ -2246,6 +2246,38 @@ describe('Bot Skill Local/Base/Cloud sync', () => {
     );
   });
 
+  test('pending evidence excludes regenerable runtime environments', () => {
+    const fixture = createFixture(roots);
+    fs.writeFileSync(path.join(fixture.skillsRoot, 'README.md'), 'durable evidence');
+    const runtimeFile = path.join(
+      fixture.skillsRoot,
+      'local-skill',
+      '.venv',
+      'lib',
+      'python',
+      'site-packages',
+      'runtime.bin',
+    );
+    fs.mkdirSync(path.dirname(runtimeFile), { recursive: true });
+    fs.writeFileSync(runtimeFile, Buffer.alloc(2 * 1024 * 1024 + 1));
+
+    const snapshot = snapshotPendingBotSkillWorkspace({
+      runtimeRoot: fixture.runtimeRoot,
+      botId: fixture.botId,
+      sourcePath: fixture.skillsRoot,
+      reason: 'activation_cloud_reconcile',
+      cloudRevision: 1,
+    });
+
+    assert.equal(snapshot.fileCount, 1);
+    assert.equal(
+      fs.readFileSync(path.join(snapshot.path, 'package', 'README.md'), 'utf8'),
+      'durable evidence',
+    );
+    assert.equal(fs.existsSync(path.join(snapshot.path, 'package', 'local-skill', '.venv')), false);
+    assert.equal(fs.existsSync(runtimeFile), true);
+  });
+
   test('pending evidence refuses a workspace root symbolic link', () => {
     const fixture = createFixture(roots);
     const external = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-bot-skills-external-'));

--- a/tests/skillhub-local-metadata.test.ts
+++ b/tests/skillhub-local-metadata.test.ts
@@ -105,6 +105,7 @@ describe('SkillHub local metadata', () => {
         '.mypy_cache',
         '.pytest_cache',
         '.ruff_cache',
+        '.venv',
         '__pycache__',
       ]) {
         const cacheFile = path.join(skillDir, directory, 'runtime.bin');


### PR DESCRIPTION
## 问题

服务器 Skill 可能在自身目录中创建 Python 虚拟环境 `.venv`。SkillHub 在列出工作区时会递归扫描该目录，文件数或采样字节超过保护上限后返回 `WORKSPACE_TOO_LARGE`，页面显示 “The local Skill workspace is too large to list safely.”。

同一目录也可能包含 Python 创建的符号链接，导致本地待处理快照被拒绝。

## 修改

- 将精确目录名 `.venv` 纳入可再生成的运行期目录集合。
- Skill 包收集、内容哈希、SkillHub 有效/无效条目指纹统一跳过 `.venv`。
- 本地待处理快照跳过真实的 `.venv` 目录，但仍拒绝名为 `.venv` 的符号链接以及其他未知符号链接。
- 不删除、不移动运行工作区中的 `.venv`，Skill 运行环境仍保留在原位置。

## 风险边界

- 仅忽略精确名称 `.venv`，不扩大到任意隐藏目录或任意 `venv` 名称。
- `.venv` 不会被发布到 SkillHub，也不会影响发布状态哈希。
- 普通工作区文件继续进入快照，现有路径和符号链接保护不变。

## 验证

- `npm run build`
- `npm run test:skillhub-phase1`
- 结果：290 passed，3 skipped（Windows 当前用户无法创建符号链接），0 failed。
