### PR TITLE
fix(skills): restore bundled prompt editing and default reset

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -15,10 +15,17 @@ Electron 开发版或打包版默认使用的用户 Skill 工作区。
 不要在运行 Electron 版时通过编辑仓库根目录 `skills/` 来判断当前 Agent 的
 Skill 状态。WebApp 的“本地工作区”会显示真正生效的绝对路径。
 
-当前资源包括 `catsco-prompt-editor/`（按需复制安装到 bot 工作区）和
-`xiaoba-knowledge/`（实例内置回退，工作区无同名 Skill 时可用）。知识库 Skill
-不在云端 BotDefinition 清单中，不能通过删除 bot 的云端 Skill 关闭；知识正文
+当前资源包括 `catsco-prompt-editor/` 和 `xiaoba-knowledge/`，两者都由运行时
+从安装包加载，工作区无同名 Skill 时自动可用，不需要复制安装。已有同名用户
+Skill 保留优先级，不自动覆盖。两者不在云端 BotDefinition 的 Skill 清单中，
+不能通过删除 bot 的云端 Skill 关闭；知识正文
 单独保存在 `<userData>/knowledge/`。详见 `docs/shared-local-knowledge.md`。
+
+提示词编辑 Skill 的 helper 支持 `show/set/reset`，无 Dashboard 也可执行。
+绑定员工使用所有者认证和版本前置条件保存云端提示词，再读回并应用本机；
+离线或冲突不降级成未同步的本地写入。恢复默认选择 `default` 并保留自定义草稿。
+实际生效在下一用户轮，不能把落盘或技能加载成功当作模型行为验收。
+旧 Dashboard 安装入口仅确认可用性，不再复制技能或覆盖用户目录。
 
 ## 按 Bot 隔离
 
@@ -106,7 +113,7 @@ invocable: user
 
 ## 注意事项
 
-- ✅ 当前 Bot 安装的 Skills 从当前运行时 `skills/` 工作区加载；知识库另有安装包内置回退
+- ✅ 当前 Bot 安装的 Skills 从当前运行时 `skills/` 工作区加载；知识库和提示词编辑器另有安装包内置回退
 - ✅ 每个 Skill 一个独立文件夹
 - ✅ 必须包含 `SKILL.md` 文件
 - ✅ 支持从 GitHub 直接安装

--- a/skills/catsco-prompt-editor/SKILL.md
+++ b/skills/catsco-prompt-editor/SKILL.md
@@ -1,48 +1,66 @@
 ---
 name: catsco-prompt-editor
-description: Safely inspect, propose, and apply CatsCo prompt changes through local prompt overrides. Use when asked to tune system prompts, compare prompt variants, or let a companion/pet agent suggest prompt edits without changing source code.
+description: 查看、按用户要求自定义或修改当前 CatsCo 员工的 system prompt，以及恢复默认提示词。适用于用户明确要求改变长期工作规则、回复风格或提示词；临时会话偏好不必持久化。
 ---
 
-# CatsCo Prompt Editor
+# 当前员工的提示词
 
-Use this skill to improve CatsCo prompts without distracting the main agent from the user's task.
+用户可以查看和修改自己员工的主 system prompt，也可以恢复当前安装版本的默认提示词。这不是要求改模型厂商的隐藏指令。只操作当前员工的主提示词，不修改 runtime、sidecar、子代理提示、工具权限、模型、Skill 订阅或其他员工配置。
 
-## Operating Rules
+绑定员工的修改影响该员工的所有会话和同步设备，不只是当前聊天。只在所有者明确要求修改或恢复默认时执行；群聊参与者不是天然的所有者。授权或目标不清时先确认。用户已明确批准的具体修改无需重复确认；只问“看看/建议怎么改”时只查看或提案，不保存。
 
-- Treat prompt editing as a side workflow: diagnose, propose, ask for confirmation, then apply.
-- Prefer local prompt overrides over editing built-in prompt files. Built-in files are the baseline; overrides are the experiment layer.
-- Only edit `system-prompt.md`. Runtime, sidecar, and sub-agent prompts are fixed implementation details.
-- Do not edit `src/`, tool schemas, provider adapters, credentials, or user data unless the user explicitly asks for code changes.
-- Never put secrets, private file contents, long chat transcripts, screenshots, or API keys into prompt files.
+## 唯一操作入口
 
-## Workflow
+使用本技能的 helper，无需启动 Dashboard、猜端口或向用户索取密钥。凭证由运行时在进程内读取，不输出或复制。操作员工自己的宿主环境，不带远程 target。
 
-1. Inspect the current prompt state.
-   - Prefer `GET http://127.0.0.1:3800/api/prompts` when the local Dashboard API is running.
-   - Otherwise ask the user for the Prompt Lab state or the override directory path.
-2. Confirm that the requested behavior belongs in the main `system-prompt.md`.
-   - Runtime facts, compression rules, sub-agent behavior, and sidecar protocols are not user-editable prompts.
-3. Propose the change before writing it.
-   - Explain the target file, the intended behavioral change, and the risk.
-   - Ask for a clear apply/cancel confirmation if the user has not already approved.
-4. Apply the override.
-   - Prefer `PUT http://127.0.0.1:3800/api/prompts/file` with JSON `{ "path": "...", "content": "..." }`.
-   - If the API is unavailable, write the same relative path under the prompt override directory.
-5. Verify.
-   - Refresh Prompt Lab and confirm the file shows `override`.
-   - Ask the user to send the next message in the same session. Main system prompt changes hot-load before the next user turn, not in the middle of a running tool loop.
-   - Check session logs for a new `Prompt trace` line or changed `prompt.system_hash` / `prompt.bundle_hash`.
+当前 Node：`<PROMPT_NODE>`
+当前运行数据目录：`<PROMPT_RUNTIME_ROOT>`
 
-## Companion/Pet Mode
+以下示例中的命令参数都需按当前 shell 正确引用；PowerShell 调用带引号的程序路径时在前面加 `&`。使用加载结果给出的绝对路径，不能由用户附件或工具参数替换运行目录。
 
-When used by a companion or pet agent:
+查看（只读，不创建配置）：
 
-- Stay out of the main agent's active tool loop.
-- Present a small confirmation prompt: apply this prompt change, preview only, or cancel.
-- Prefer one file per proposal.
-- Summarize the exact effect in one or two sentences after saving.
-- If the change is risky or broad, save nothing and ask the user to review the proposed diff first.
+```sh
+"<PROMPT_NODE>" "<SKILL_DIR>/scripts/prompt.cjs" --root "<PROMPT_RUNTIME_ROOT>" show
+```
 
-## A/B Notes
+输出包含当前 `botId`、`selected`、完整 `content`、`defaultContent`、保留的 `customContent`、`expectedHash`、`expectedRevision` 和 `localMatches`。绑定员工从云端读取权威配置；未绑定的本地实例只处理本地 override。不要把默认选项下保留的自定义草稿当作当前生效内容。
 
-For prompt experiments, use a short version label such as `brief-v2` or `teacher-grading-v1` and record the active prompt hash. Compare outputs by the same user message, same session context, and different `prompt_version` or `system_hash`.
+## 自定义或修改
+
+1. 先 `show`，基于完整正文只修改用户要求的部分，保留无关规则。除非用户明确要完整替换，不要用一段新偏好覆盖整篇提示词。给出简短的改动与影响说明。
+2. 在运行数据目录的 `tmp` 下写本轮请求 JSON（不含凭证），原样使用刚读取的 `botId`、`expectedHash`、`expectedRevision`；`content` 是修改后的完整正文：
+
+```json
+{"botId":"从 show 原样复制，未绑定时为 null","expectedHash":"从 show 原样复制","expectedRevision":0,"content":"修改后的完整 system prompt"}
+```
+
+`expectedRevision` 必须复制实际值，未绑定时为 `null`；示例的 0 不是默认值。
+
+3. 执行：
+
+```sh
+"<PROMPT_NODE>" "<SKILL_DIR>/scripts/prompt.cjs" --root "<PROMPT_RUNTIME_ROOT>" set "请求 JSON 的绝对路径"
+```
+
+不要把私钥、令牌、长聊天记录、临时路径或未核实资料塞进提示词。用户只是要求记住项目事实时，使用知识库，不改 system prompt。
+
+## 恢复默认
+
+先 `show`；创建同样的请求 JSON，保留三个前置条件字段，但不提供 `content`，然后：
+
+```sh
+"<PROMPT_NODE>" "<SKILL_DIR>/scripts/prompt.cjs" --root "<PROMPT_RUNTIME_ROOT>" reset "请求 JSON 的绝对路径"
+```
+
+这是选择 `default`，不是把默认文字另存为 `custom`。绑定员工保留先前自定义草稿，不删除知识、历史会话或其他配置。默认正文随安装版本更新。想重新启用保留草稿时，用 `show.customContent` 作为完整 `content` 执行 `set`。
+
+## 验证与失败处理
+
+- 写入后再次 `show`，核对全文或哈希、所选模式，以及 `localMatches=true`。只有绑定员工返回 `cloudVerified=true` 且 `localMatches=true`，才能说云端保存和本机落盘均已确认；本地实例只说本地保存。
+- 主提示词在下一条用户消息开始时热加载，不改变正在执行的工具循环。不要自行重启服务或制造新用户消息。需要证明实际请求已使用新版本时，在下一轮核对 prompt trace；不能把落盘成功说成已验证模型行为。
+- 冲突表示查看后配置发生变化，重新读取并比较，必要时重新征求用户确认；不要自动覆盖新版本。
+- 云端不可用、未登录所有者、权限不足、配置未初始化时，明确报告阻碍，不用直接写 override、缓存文件、数据库或旧 Dashboard 接口绕过。
+- `cloudWritten=true` 但 `ok=false` 表示云端已提交、本地应用或读回未确认。不要重复提交或声称完全成功，先只读查看状态，报告待同步范围。
+- `cloudWriteUnconfirmed=true` 表示写请求已发出但未收到成功确认（例如超时）；也可能已经提交，先 `show` 核对，不盲目重试。
+- 只有实际写入并读回后才说“已修改/已恢复”；口头承诺不算保存。清理本轮请求 JSON，不删除用户文件。

--- a/skills/catsco-prompt-editor/scripts/prompt.cjs
+++ b/skills/catsco-prompt-editor/scripts/prompt.cjs
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+'use strict';
+
+// Fixed package-relative entrypoint: never load executable code from runtime data.
+const path = require('node:path');
+const args = process.argv.slice(2);
+if (args[0] !== '--root' || !args[1] || !path.isAbsolute(args[1])) {
+  console.error(JSON.stringify({ ok: false, code: 'INVALID_ROOT', message: 'An absolute --root is required.' }));
+  process.exitCode = 1;
+} else {
+  const root = path.resolve(args[1]);
+  process.env.XIAOBA_USER_DATA_DIR = root;
+  process.env.XIAOBA_RUNTIME_ROOT = root;
+  process.env.XIAOBA_APP_ROOT = path.resolve(__dirname, '../../..');
+  require('../../../dist/skills/prompt-editor-command.js').runPromptEditorCommand(args.slice(2))
+    .then(result => {
+      console.log(JSON.stringify(result));
+      if (!result.ok) process.exitCode = 1;
+    })
+    .catch(() => {
+      console.error(JSON.stringify({ ok: false, code: 'HELPER_FAILED', message: 'Prompt helper failed; no success is confirmed.' }));
+      process.exitCode = 1;
+    });
+}

--- a/src/commands/skill.ts
+++ b/src/commands/skill.ts
@@ -3,6 +3,7 @@ import { Logger } from '../utils/logger';
 import { styles } from '../theme/colors';
 import { SkillManager } from '../skills/skill-manager';
 import { isBuiltinKnowledgeSkillFile } from '../skills/builtin-knowledge-skill';
+import { PROMPT_EDITOR_SKILL_FILE } from '../skills/builtin-prompt-editor-skill';
 import { PathResolver } from '../utils/path-resolver';
 import { execSync } from 'child_process';
 import chalk from 'chalk';
@@ -294,8 +295,8 @@ async function removeLocalSkill(name: string, force?: boolean): Promise<void> {
     process.exit(1);
   }
 
-  if (isBuiltinKnowledgeSkillFile(skill.filePath)) {
-    Logger.error('知识库 Skill 随应用分发，不能移除安装包中的文件；可在用户 Skill 目录安装同名 Skill 自定义流程。');
+  if (isBuiltinKnowledgeSkillFile(skill.filePath) || path.resolve(skill.filePath) === PROMPT_EDITOR_SKILL_FILE) {
+    Logger.error('内置 Skill 随应用分发，不能移除安装包中的文件；可在用户 Skill 目录安装同名 Skill 自定义流程。');
     process.exitCode = 1;
     return;
   }

--- a/src/dashboard/routes/api.ts
+++ b/src/dashboard/routes/api.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import { SkillManager } from '../../skills/skill-manager';
 import { isBuiltinKnowledgeSkillFile } from '../../skills/builtin-knowledge-skill';
+import { PROMPT_EDITOR_SKILL_FILE } from '../../skills/builtin-prompt-editor-skill';
 import type { Skill } from '../../types/skill';
 import { ConfigManager } from '../../utils/config';
 import { ServiceManager } from '../service-manager';
@@ -4572,52 +4573,14 @@ function sanitizeServerUrl(serverUrl?: string): string | undefined {
   }
 }
 
-function installPromptEditorSeedSkill(options: { overwrite?: boolean } = {}): any {
-  const sourceDir = resolvePromptEditorSeedSkillDir();
-  const sourceSkillFile = path.join(sourceDir, 'SKILL.md');
-  if (!fs.existsSync(sourceSkillFile)) {
-    throw new Error('Prompt editor seed skill is missing from this build.');
-  }
-
-  const skillsRoot = PathResolver.getSkillsPath();
-  PathResolver.ensureDir(skillsRoot);
-  const targetDir = resolveChildDirectory(skillsRoot, PROMPT_EDITOR_SKILL_NAME);
-  const targetSkillFile = path.join(targetDir, 'SKILL.md');
-  const disabledSkillFile = targetSkillFile + '.disabled';
-  const targetDirExists = fs.existsSync(targetDir);
-  const existing = targetDirExists || fs.existsSync(targetSkillFile) || fs.existsSync(disabledSkillFile);
-
-  if (existing && !options.overwrite) {
-    return {
-      ok: true,
-      installed: false,
-      existing: true,
-      name: PROMPT_EDITOR_SKILL_NAME,
-      path: fs.existsSync(targetSkillFile)
-        ? targetSkillFile
-        : (fs.existsSync(disabledSkillFile) ? disabledSkillFile : targetDir),
-      disabled: !fs.existsSync(targetSkillFile),
-    };
-  }
-
-  if (targetDirExists) {
-    fs.rmSync(targetDir, { recursive: true, force: true });
-  }
-  fs.mkdirSync(path.dirname(targetSkillFile), { recursive: true });
-  fs.cpSync(sourceDir, targetDir, {
-    recursive: true,
-    filter: source => {
-      const name = path.basename(source).toLowerCase();
-      return name !== '.git' && name !== 'node_modules' && name !== '__pycache__';
-    },
-  });
-
+function installPromptEditorSeedSkill(_options: { overwrite?: boolean } = {}): any {
+  // Compatibility endpoint: the editor is now bundled and always discoverable.
+  // Do not copy package-relative helpers into user data or erase user overrides.
+  const target = path.join(PathResolver.getSkillsPath(), PROMPT_EDITOR_SKILL_NAME, 'SKILL.md');
   return {
-    ok: true,
-    installed: true,
-    existing: false,
+    ok: true, installed: false, existing: true, available: true,
     name: PROMPT_EDITOR_SKILL_NAME,
-    path: targetSkillFile,
+    path: fs.existsSync(target) ? target : PROMPT_EDITOR_SKILL_FILE,
   };
 }
 
@@ -4627,32 +4590,6 @@ function requireJsonWrite(req: any, res: any): boolean {
   return false;
 }
 
-function resolvePromptEditorSeedSkillDir(): string {
-  const candidates = [
-    process.env.XIAOBA_APP_ROOT,
-    process.cwd(),
-    path.resolve(__dirname, '../../..'),
-  ].filter((value): value is string => Boolean(value));
-
-  for (const candidate of candidates) {
-    const skillDir = path.join(path.resolve(candidate), 'skills', PROMPT_EDITOR_SKILL_NAME);
-    if (fs.existsSync(path.join(skillDir, 'SKILL.md'))) {
-      return skillDir;
-    }
-  }
-
-  return path.join(path.resolve(candidates[0] || process.cwd()), 'skills', PROMPT_EDITOR_SKILL_NAME);
-}
-
-function resolveChildDirectory(rootDir: string, childName: string): string {
-  const root = path.resolve(rootDir);
-  const target = path.resolve(root, childName);
-  const relative = path.relative(root, target);
-  if (relative.startsWith('..') || path.isAbsolute(relative)) {
-    throw new Error(`Unsafe target path: ${childName}`);
-  }
-  return target;
-}
 
 // ==================== Helpers ====================
 
@@ -4722,7 +4659,7 @@ async function getSkillHubInstallInfo(skill: Skill): Promise<any> {
 }
 
 function getSkillManagementInfo(skillFilePath: string): SkillManagementInfo {
-  if (isBuiltinKnowledgeSkillFile(skillFilePath)) {
+  if (isBuiltinKnowledgeSkillFile(skillFilePath) || path.resolve(skillFilePath) === PROMPT_EDITOR_SKILL_FILE) {
     return { source: 'system', protected: true, canDisable: false, canDelete: false, canShare: false };
   }
   const dir = path.dirname(skillFilePath);

--- a/src/skills/builtin-prompt-editor-skill.ts
+++ b/src/skills/builtin-prompt-editor-skill.ts
@@ -1,0 +1,20 @@
+import * as path from 'path';
+import { Skill } from '../types/skill';
+import { PathResolver } from '../utils/path-resolver';
+import { SkillParser } from './skill-parser';
+
+export const PROMPT_EDITOR_SKILL_FILE = path.resolve(__dirname, '../../skills/catsco-prompt-editor/SKILL.md');
+
+export function loadBuiltinPromptEditorSkill(): Skill {
+  return SkillParser.parse(PROMPT_EDITOR_SKILL_FILE);
+}
+
+export function renderPromptEditorPaths(skill: Skill): Skill {
+  if (path.resolve(skill.filePath) !== PROMPT_EDITOR_SKILL_FILE) return skill;
+  return {
+    ...skill,
+    content: skill.content
+      .replace(/<PROMPT_RUNTIME_ROOT>/g, () => PathResolver.getRuntimeDataRoot())
+      .replace(/<PROMPT_NODE>/g, () => process.env.XIAOBA_NODE_EXECUTABLE?.trim() || process.execPath),
+  };
+}

--- a/src/skills/prompt-editor-command.ts
+++ b/src/skills/prompt-editor-command.ts
@@ -1,0 +1,159 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { createCatsCoLocalConfigService } from '../catscompany/local-config';
+import { pullCloudBotDefinition, patchCloudBotDefinitionPrompt } from '../bot-definition/cloud-client';
+import { createBotDefinitionCloudSyncService } from '../bot-definition/cloud-sync';
+import { getPromptReconcileCoordinator, hashPrompt } from '../bot-definition/prompt-sync';
+import { createBotDefinitionSyncService } from '../bot-definition/service';
+import { BotPromptDefinition } from '../bot-definition/types';
+import { PathResolver } from '../utils/path-resolver';
+import { getPromptEditorFile, writePromptOverride, deletePromptOverride } from '../utils/prompt-editor';
+import { normalizePromptText, readRequiredBundledPromptFile } from '../utils/prompt-template';
+
+const MAX_BYTES = 256 * 1024;
+const PROMPT_FILE = 'system-prompt.md';
+
+export interface PromptCommandOptions {
+  runtimeRoot?: string;
+  env?: NodeJS.ProcessEnv;
+  fetchImpl?: typeof fetch;
+}
+
+class PromptCommandError extends Error {
+  constructor(readonly code: string, message: string) { super(message); }
+}
+
+function fail(code: string, message: string): never { throw new PromptCommandError(code, message); }
+
+export async function runPromptEditorCommand(args: string[], options: PromptCommandOptions = {}): Promise<any> {
+  let cloudWritten = false;
+  let writeAttempted = false;
+  try {
+    const [operation, requestFile] = args;
+    if (!['show', 'set', 'reset'].includes(operation) || args.length !== (operation === 'show' ? 1 : 2)) {
+      fail('INVALID_ARGUMENTS', 'Use show, set <request.json>, or reset <request.json>.');
+    }
+    const env = options.env ?? process.env;
+    const runtimeRoot = path.resolve(options.runtimeRoot ?? PathResolver.getRuntimeDataRoot(env));
+    const config = createCatsCoLocalConfigService({ runtimeRoot, env });
+    const auth = config.getAuthState();
+    // An env-bound headless worker must never fall back to unbound local editing.
+    const botId = config.load().currentBot?.uid?.trim() || auth.botUid?.trim() || null;
+    const defaultContent = readRequiredBundledPromptFile(PROMPT_FILE, env);
+    const definitionService = createBotDefinitionSyncService({ runtimeRoot, env });
+    const cloud = createBotDefinitionCloudSyncService({ runtimeRoot, env, definitionService, fetchImpl: options.fetchImpl });
+    const coordinator = getPromptReconcileCoordinator({ runtimeRoot, env, definitionService, cloudSyncService: cloud });
+    const clientOptions = botId ? { botId, auth, fetchImpl: options.fetchImpl } : undefined;
+
+    const show = async () => {
+      let prompt: BotPromptDefinition;
+      let revision: number | null = null;
+      let localContent: string;
+      if (botId) {
+        const snapshot = await pullCloudBotDefinition(clientOptions!);
+        if (!snapshot?.configured || !snapshot.definition?.prompt) {
+          fail('CLOUD_UNAVAILABLE', 'Cannot read an initialized cloud prompt. No local fallback is used.');
+        }
+        prompt = snapshot.definition.prompt;
+        revision = snapshot.revision;
+        const file = coordinator.getActivePromptPath();
+        localContent = fs.existsSync(file) ? normalizePromptText(fs.readFileSync(file, 'utf8')) : '';
+      } else {
+        // Local helpers run with the explicitly selected root, never an unrelated cwd.
+        if (path.resolve(PathResolver.getRuntimeDataRoot()) !== runtimeRoot) {
+          fail('RUNTIME_MISMATCH', 'Local editing requires the helper runtime root to match the active environment.');
+        }
+        const file = getPromptEditorFile(PROMPT_FILE);
+        localContent = file.content;
+        const override = path.join(runtimeRoot, 'prompt-overrides', PROMPT_FILE);
+        prompt = fs.existsSync(override)
+          ? { selected: 'custom', customSystemPrompt: file.content }
+          : { selected: 'default' };
+      }
+      const content = prompt.selected === 'custom' ? prompt.customSystemPrompt! : defaultContent;
+      return {
+        ok: true, botId, selected: prompt.selected, content, defaultContent,
+        customContent: prompt.customSystemPrompt ?? null,
+        expectedRevision: revision,
+        expectedHash: hashPrompt(JSON.stringify({ botId, prompt, defaultContent, localContent })),
+        cloudVerified: Boolean(botId),
+        localMatches: localContent === content,
+      };
+    };
+
+    const before = await show();
+    if (operation === 'show') return before;
+    if (!requestFile || !path.isAbsolute(requestFile) || fs.statSync(requestFile).size > MAX_BYTES * 6 + 4096) {
+      fail('INVALID_REQUEST', 'Use an absolute path to a bounded JSON request file.');
+    }
+    const request = JSON.parse(fs.readFileSync(requestFile, 'utf8'));
+    if (!request || typeof request !== 'object' || Array.isArray(request)
+      || Object.keys(request).some(key => !['botId', 'expectedHash', 'expectedRevision', 'content'].includes(key))) {
+      fail('INVALID_REQUEST', 'Unexpected request fields. Only the main prompt can be edited.');
+    }
+    if (request.botId !== before.botId || request.expectedHash !== before.expectedHash
+      || request.expectedRevision !== before.expectedRevision) {
+      fail('CONFLICT', 'The bot or prompt changed since show. Read again and review before applying.');
+    }
+    if (operation === 'reset' && request.content !== undefined) fail('INVALID_REQUEST', 'Reset must not include content.');
+    const content = typeof request.content === 'string' ? normalizePromptText(request.content) : '';
+    if (operation === 'set' && (!content || Buffer.byteLength(content, 'utf8') > MAX_BYTES)) {
+      fail('INVALID_CONTENT', 'Custom prompt must be nonempty and at most 256 KiB.');
+    }
+    const selected = operation === 'set' ? 'custom' : 'default';
+    const prompt: BotPromptDefinition = {
+      selected,
+      ...(operation === 'set' ? { customSystemPrompt: content }
+        : before.customContent ? { customSystemPrompt: before.customContent } : {}),
+    };
+    const assertCurrentBot = () => {
+      const current = config.load().currentBot?.uid?.trim() || config.getAuthState().botUid?.trim() || null;
+      if (current !== botId) fail('BOT_CHANGED', 'The active bot changed; local application was stopped.');
+    };
+    assertCurrentBot();
+    if (botId) {
+      if (!auth.token || !auth.uid || auth.uid !== auth.ownerUid) {
+        fail('OWNER_AUTH_REQUIRED', 'A signed-in bot owner is required. No local edit was made.');
+      }
+      if (cloud.readState(botId).pendingPrompt) {
+        fail('PENDING_LOCAL_EDIT', 'An earlier local prompt is pending sync. Resolve it before a new edit.');
+      }
+      // Cloud-first CAS. In contrast to background reconciliation, a user edit
+      // must not silently retry a stale revision and overwrite another edit.
+      writeAttempted = true;
+      const revision = await patchCloudBotDefinitionPrompt(clientOptions!, prompt, before.expectedRevision!);
+      if (revision === undefined) fail('CLOUD_UNAVAILABLE', 'Cloud prompt editing is unavailable. No local edit was made.');
+      cloudWritten = true;
+      assertCurrentBot();
+      const snapshot = await cloud.pull(botId, auth);
+      if (!snapshot?.definition || snapshot.revision !== revision
+        || snapshot.definition.prompt?.selected !== selected
+        || (snapshot.definition.prompt?.customSystemPrompt ?? null) !== (prompt.customSystemPrompt ?? null)) {
+        fail('VERIFY_FAILED', 'Cloud changed or could not be verified after saving. Inspect before retrying.');
+      }
+      assertCurrentBot();
+      await coordinator.activateBot(botId, { preferDefinition: true });
+    } else if (operation === 'set') {
+      writePromptOverride(PROMPT_FILE, content);
+    } else {
+      deletePromptOverride(PROMPT_FILE);
+    }
+    assertCurrentBot();
+    const after = await show();
+    if (after.selected !== selected || !after.localMatches
+      || after.content !== (selected === 'custom' ? content : defaultContent)) {
+      fail('VERIFY_FAILED', 'Saved state did not match the requested prompt; inspect before retrying.');
+    }
+    return { ...after, cloudWritten, takesEffect: 'next_user_turn' };
+  } catch (error) {
+    // Never echo raw upstream responses, credentials, or malformed JSON text.
+    const status = (error as { status?: number })?.status;
+    const known = error instanceof PromptCommandError;
+    return {
+      ok: false, cloudWritten,
+      ...(writeAttempted && !cloudWritten ? { cloudWriteUnconfirmed: true } : {}),
+      code: known ? error.code : status === 409 ? 'CONFLICT' : status === 401 || status === 403 ? 'PERMISSION_DENIED' : 'PROMPT_OPERATION_FAILED',
+      message: known ? error.message : 'Prompt operation failed. Inspect state before retrying; no success is confirmed.',
+    };
+  }
+}

--- a/src/skills/skill-manager.ts
+++ b/src/skills/skill-manager.ts
@@ -4,6 +4,7 @@ import { PathResolver } from '../utils/path-resolver';
 import { SkillParser } from './skill-parser';
 import { Logger } from '../utils/logger';
 import { loadBuiltinKnowledgeSkill } from './builtin-knowledge-skill';
+import { loadBuiltinPromptEditorSkill } from './builtin-prompt-editor-skill';
 
 /**
  * Skills 管理器
@@ -18,7 +19,7 @@ export class SkillManager {
   }
 
   /**
-   * 加载用户 Skill 工作区和随应用分发的知识库指导。
+   * 加载用户 Skill 工作区和随应用分发的内置指导。
    */
   async loadSkills(): Promise<void> {
     const skillsPath = this.fixedSkillsPath ?? PathResolver.getSkillsPath();
@@ -28,8 +29,9 @@ export class SkillManager {
     const nextSkills = loadedSkills ?? new Map(this.skills);
     // Bundled guidance stays outside the mutable/synced bot Skill workspace.
     // A local Skill with the same name remains an explicit user override.
-    const builtin = loadBuiltinKnowledgeSkill();
-    if (!nextSkills.has(builtin.metadata.name)) nextSkills.set(builtin.metadata.name, builtin);
+    for (const builtin of [loadBuiltinKnowledgeSkill(), loadBuiltinPromptEditorSkill()]) {
+      if (!nextSkills.has(builtin.metadata.name)) nextSkills.set(builtin.metadata.name, builtin);
+    }
     // Readers keep seeing the previous complete snapshot while files are
     // enumerated and parsed. Publish the new snapshot in one assignment.
     this.skills = nextSkills;

--- a/src/tools/skill-tool.ts
+++ b/src/tools/skill-tool.ts
@@ -3,6 +3,7 @@ import { SkillManager } from '../skills/skill-manager';
 import { SkillInvocationContext } from '../types/skill';
 import { SkillExecutor } from '../skills/skill-executor';
 import { renderKnowledgePaths } from '../skills/builtin-knowledge-skill';
+import { renderPromptEditorPaths } from '../skills/builtin-prompt-editor-skill';
 import { Logger } from '../utils/logger';
 import { getPetService } from '../pet/pet-service';
 import { PetEventType } from '../pet/pet-types';
@@ -99,7 +100,7 @@ export class SkillTool implements Tool {
       this.recordPetEvent('skill_started', skillName, context);
 
       // 直接返回渲染后的 SKILL.md 内容，由 tool_result 并入上下文
-      const result = SkillExecutor.execute(renderKnowledgePaths(skill, context), invocationContext);
+      const result = SkillExecutor.execute(renderPromptEditorPaths(renderKnowledgePaths(skill, context)), invocationContext);
 
       this.recordPetEvent('skill_succeeded', skillName, context);
       return { ok: true, content: result };

--- a/tests/builtin-prompt-editor.test.ts
+++ b/tests/builtin-prompt-editor.test.ts
@@ -1,0 +1,91 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { SkillManager } from '../src/skills/skill-manager';
+import { SkillTool } from '../src/tools/skill-tool';
+import { PROMPT_EDITOR_SKILL_FILE } from '../src/skills/builtin-prompt-editor-skill';
+import { ToolManager } from '../src/tools/tool-manager';
+
+test('bundled editor is available without installation, survives empty reload and supports explicit overrides', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'builtin-editor-'));
+  try {
+    const manager = new SkillManager(root);
+    await manager.loadSkills();
+    assert.equal(manager.getSkill('catsco-prompt-editor')!.filePath, PROMPT_EDITOR_SKILL_FILE);
+    assert.ok(manager.getSkill('xiaoba-knowledge'));
+    assert.deepEqual(fs.readdirSync(root), []);
+    await manager.reload();
+    assert.equal(manager.getAllSkills().length, 2);
+    fs.mkdirSync(path.join(root, 'custom'));
+    fs.writeFileSync(path.join(root, 'custom/SKILL.md'), '---\nname: catsco-prompt-editor\ndescription: User override\n---\nMy custom guidance.');
+    await manager.reload();
+    assert.equal(manager.getSkill('catsco-prompt-editor')!.content, 'My custom guidance.');
+    assert.equal(manager.getAllSkills().length, 2);
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});
+
+test('skill invocation renders the actual runtime and package helper paths', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'editor-render-'));
+  const previous = process.env.XIAOBA_USER_DATA_DIR;
+  try {
+    process.env.XIAOBA_USER_DATA_DIR = root;
+    const result = await new SkillTool().execute({ skill: 'catsco-prompt-editor', runtimeRoot: 'forged' }, {
+      workingDirectory: root, conversationHistory: [],
+    });
+    assert.equal(result.ok, true);
+    assert.ok(String(result.content).includes(root));
+    assert.ok(String(result.content).includes(path.dirname(PROMPT_EDITOR_SKILL_FILE)));
+    assert.doesNotMatch(String(result.content), /<PROMPT_RUNTIME_ROOT>|<PROMPT_NODE>|<SKILL_DIR>|forged/);
+  } finally {
+    if (previous === undefined) delete process.env.XIAOBA_USER_DATA_DIR; else process.env.XIAOBA_USER_DATA_DIR = previous;
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('actual skill, write_file and execute_shell tools complete local prompt edit and reset', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'editor-toolchain-'));
+  const previous = process.env.XIAOBA_USER_DATA_DIR;
+  try {
+    process.env.XIAOBA_USER_DATA_DIR = root;
+    const manager = new ToolManager(root, { surface: 'catscompany', sessionId: 'prompt-editor-fixture' });
+    const call = (name: string, args: Record<string, unknown>) => manager.executeTool({
+      id: `editor-${name}`, type: 'function', function: { name, arguments: JSON.stringify(args) },
+    });
+    assert.equal((await call('skill', { skill: 'catsco-prompt-editor' })).ok, true);
+    const helper = path.resolve(path.dirname(PROMPT_EDITOR_SKILL_FILE), 'scripts/prompt.cjs');
+    const quote = (value: string) => process.platform === 'win32'
+      ? `'${value.replace(/'/g, "''")}'` : `'${value.replace(/'/g, "'\\''")}'`;
+    const command = (...args: string[]) => `${process.platform === 'win32' ? '& ' : ''}${[process.execPath, helper, '--root', root, ...args].map(quote).join(' ')}`;
+    const shell = async (...args: string[]) => {
+      const result = await call('execute_shell', { command: command(...args) });
+      assert.equal(result.ok, true, String(result.content));
+      const json = String(result.content).split(/\r?\n/).find(line => line.startsWith('{"ok":'));
+      assert.ok(json, String(result.content));
+      return JSON.parse(json);
+    };
+    const input = path.join(root, 'request.json');
+    let state = await shell('show');
+    const initial = state.content;
+    const writeRequest = async (content?: string) => {
+      const result = await call('write_file', { file_path: input, content: JSON.stringify({
+        botId: state.botId, expectedHash: state.expectedHash, expectedRevision: state.expectedRevision,
+        ...(content !== undefined ? { content } : {}),
+      }) });
+      assert.equal(result.ok, true);
+    };
+    await writeRequest('Only the requested user preference.');
+    await shell('set', input);
+    state = await shell('show');
+    assert.equal(state.content, 'Only the requested user preference.');
+    assert.equal(state.localMatches, true);
+    await writeRequest();
+    state = await shell('reset', input);
+    assert.equal(state.content, initial);
+    assert.equal(state.selected, 'default');
+  } finally {
+    if (previous === undefined) delete process.env.XIAOBA_USER_DATA_DIR; else process.env.XIAOBA_USER_DATA_DIR = previous;
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/tests/bundled-knowledge-runtime.test.ts
+++ b/tests/bundled-knowledge-runtime.test.ts
@@ -29,6 +29,7 @@ test('compiled knowledge runtime works from isolated CLI, desktop and Worker res
         fs.mkdirSync(data);
         fs.cpSync(path.join(repo, 'dist'), path.join(app, 'dist'), { recursive: true });
         fs.cpSync(path.join(repo, 'skills/xiaoba-knowledge'), path.join(app, 'skills/xiaoba-knowledge'), { recursive: true });
+        fs.cpSync(path.join(repo, 'skills/catsco-prompt-editor'), path.join(app, 'skills/catsco-prompt-editor'), { recursive: true });
         const env = { ...process.env, NODE_PATH: path.join(repo, 'node_modules'), XIAOBA_USER_DATA_DIR: data,
           XIAOBA_SKILLS_DIR: path.join(data, 'skills'), XIAOBA_NODE_EXECUTABLE: process.execPath };
         const program = `

--- a/tests/bundled-prompt-editor-runtime.test.ts
+++ b/tests/bundled-prompt-editor-runtime.test.ts
@@ -1,0 +1,98 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import * as http from 'node:http';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const run = promisify(execFile);
+const repo = path.resolve(__dirname, '..');
+
+test('packaged prompt helper runs without Dashboard from CLI, desktop and Worker layouts', { timeout: 60000 }, async t => {
+  assert.ok(fs.existsSync(path.join(repo, 'dist/skills/prompt-editor-command.js')), 'Compile before testing');
+  for (const layout of ['cli-app', 'desktop/resources/app', 'CatsCo.app/Contents/Resources/app', 'worker/releases/test/app']) {
+    await t.test(layout, async () => {
+      const root = fs.mkdtempSync(path.join(os.tmpdir(), 'prompt-package-'));
+      let server: http.Server | undefined;
+      try {
+        const app = path.join(root, layout);
+        const data = path.join(root, '用户 数据');
+        const cwd = path.join(root, 'unrelated-cwd');
+        fs.mkdirSync(data); fs.mkdirSync(cwd);
+        fs.cpSync(path.join(repo, 'dist'), path.join(app, 'dist'), { recursive: true });
+        fs.cpSync(path.join(repo, 'skills/catsco-prompt-editor'), path.join(app, 'skills/catsco-prompt-editor'), { recursive: true });
+        fs.cpSync(path.join(repo, 'prompts'), path.join(app, 'prompts'), { recursive: true });
+        const env = { ...process.env, NODE_PATH: path.join(repo, 'node_modules'),
+          XIAOBA_USER_DATA_DIR: data, XIAOBA_RUNTIME_ROOT: data, XIAOBA_APP_ROOT: app };
+        const script = path.join(app, 'skills/catsco-prompt-editor/scripts/prompt.cjs');
+        const call = async (...args: string[]) => JSON.parse((await run(process.execPath,
+          [script, '--root', data, ...args], { cwd, env })).stdout);
+        const input = path.join(data, '请求.json');
+        const writeRequest = (state: any, content?: string) => {
+          fs.writeFileSync(input, JSON.stringify({ botId: state.botId, expectedHash: state.expectedHash,
+            expectedRevision: state.expectedRevision, ...(content !== undefined ? { content } : {}) }));
+        };
+
+        // Fresh subprocess for every call: no reliance on an in-memory coordinator.
+        const initial = await call('show');
+        assert.equal(initial.botId, null); assert.equal(initial.selected, 'default');
+        assert.deepEqual(fs.readdirSync(data), []);
+        writeRequest(initial, 'Local custom rules');
+        const local = await call('set', input);
+        assert.equal(local.cloudVerified, false); assert.equal(local.localMatches, true);
+        writeRequest(await call('show'));
+        assert.equal((await call('reset', input)).content, initial.defaultContent);
+        assert.equal(fs.existsSync(path.join(data, 'prompt-overrides/system-prompt.md')), false);
+
+        // Real HTTP transport, synthetic cloud authority; no production users or credentials.
+        let revision = 3;
+        let prompt: any = { selected: 'default' };
+        let patchCount = 0;
+        server = http.createServer(async (req, res) => {
+          res.setHeader('Content-Type', 'application/json');
+          if (req.method === 'PATCH') {
+            if (req.url !== '/api/bots/definition/prompt?uid=982' || req.headers.authorization !== 'Bearer test-owner') {
+              res.writeHead(403).end('{}'); return;
+            }
+            let raw = ''; for await (const part of req) raw += part;
+            const body = JSON.parse(raw);
+            if (body.revision !== revision) { res.writeHead(409).end('{}'); return; }
+            prompt = body.prompt; revision++; patchCount++;
+            res.end(JSON.stringify({ revision })); return;
+          }
+          if (req.url !== '/api/bot/definition' || req.headers.authorization !== 'ApiKey test-bot') {
+            res.writeHead(403).end('{}'); return;
+          }
+          res.end(JSON.stringify({ uid: 982, configured: true, revision, definition: {
+            schema: 'xiaoba.bot-definition.v1', botId: '982',
+            model: { kind: 'catalog', modelId: 'deepseek-v4-flash' }, prompt,
+          } }));
+        });
+        await new Promise<void>(resolve => server!.listen(0, '127.0.0.1', resolve));
+        const address = server.address() as import('node:net').AddressInfo;
+        fs.mkdirSync(path.join(data, '.xiaoba'), { recursive: true });
+        fs.writeFileSync(path.join(data, '.xiaoba/catsco.json'), JSON.stringify({ version: 1,
+          endpoints: { httpBaseUrl: `http://127.0.0.1:${address.port}` },
+          account: { uid: '38', token: 'test-owner' },
+          currentBot: { uid: '982', boundByUserUid: '38', apiKey: 'test-bot', bindingSource: 'test' },
+        }));
+        writeRequest(await call('show'), 'Persisted cloud rules');
+        const saved = await call('set', input);
+        assert.equal(saved.cloudWritten, true); assert.equal(saved.cloudVerified, true); assert.equal(saved.localMatches, true);
+        assert.equal((await call('show')).content, 'Persisted cloud rules');
+        writeRequest(await call('show'));
+        const reset = await call('reset', input);
+        assert.equal(reset.selected, 'default'); assert.equal(reset.localMatches, true);
+        assert.equal(reset.customContent, 'Persisted cloud rules');
+        assert.equal(patchCount, 2);
+        assert.deepEqual(fs.readdirSync(cwd), []);
+        assert.equal(fs.existsSync(path.join(app, 'data')), false);
+      } finally {
+        if (server) await new Promise<void>(resolve => server!.close(() => resolve()));
+        await fs.promises.rm(root, { recursive: true, force: true, maxRetries: 3, retryDelay: 50 });
+      }
+    });
+  }
+});

--- a/tests/dashboard-runtime-config.test.ts
+++ b/tests/dashboard-runtime-config.test.ts
@@ -98,7 +98,7 @@ describe('dashboard runtime config snapshot', () => {
       snapshot.tools.enabled.find(tool => tool.name === 'import_file')?.transcriptMode,
       'default',
     );
-    assert.deepStrictEqual(snapshot.skills.items.map(skill => skill.name), ['snapshot-demo', 'xiaoba-knowledge']);
+    assert.deepStrictEqual(snapshot.skills.items.map(skill => skill.name), ['snapshot-demo', 'xiaoba-knowledge', 'catsco-prompt-editor']);
   });
 
   test('applies runtime profile file to dashboard snapshot with config metadata', async () => {

--- a/tests/dashboard-skills-api.test.ts
+++ b/tests/dashboard-skills-api.test.ts
@@ -64,6 +64,9 @@ describe('dashboard skills API', () => {
     const byName = new Map(skills.map(skill => [skill.name, skill]));
 
     assert.equal(response.status, 200);
+    assert.deepEqual(pickManagement(byName.get('catsco-prompt-editor')), {
+      source: 'system', protected: true, canDisable: false, canDelete: false, canShare: false,
+    });
     assert.deepEqual(pickManagement(byName.get('xiaoba-knowledge')), {
       source: 'system',
       protected: true,
@@ -126,8 +129,9 @@ describe('dashboard skills API', () => {
 
     assert.equal(install.status, 200);
     assert.equal(data.ok, true);
-    assert.equal(data.installed, true);
-    assert.equal(fs.existsSync(targetFile), true);
+    assert.equal(data.installed, false);
+    assert.equal(data.available, true);
+    assert.equal(fs.existsSync(targetFile), false);
 
     const secondInstall = await fetch(`${baseUrl}/api/prompts/editor-skill/install`, {
       method: 'POST',
@@ -164,9 +168,9 @@ describe('dashboard skills API', () => {
     });
     const overwriteData = await overwrite.json() as any;
     assert.equal(overwrite.status, 200);
-    assert.equal(overwriteData.installed, true);
-    assert.equal(fs.existsSync(path.join(targetDir, 'SKILL.md')), true);
-    assert.equal(fs.existsSync(path.join(targetDir, 'notes.txt')), false);
+    assert.equal(overwriteData.installed, false);
+    assert.equal(fs.existsSync(path.join(targetDir, 'SKILL.md')), false);
+    assert.equal(fs.readFileSync(path.join(targetDir, 'notes.txt'), 'utf8'), 'keep me');
   });
 
   test('prompt write endpoints require JSON requests', async () => {

--- a/tests/prompt-editor-command.test.ts
+++ b/tests/prompt-editor-command.test.ts
@@ -1,0 +1,180 @@
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { runPromptEditorCommand } from '../src/skills/prompt-editor-command';
+import { createCatsCoLocalConfigService } from '../src/catscompany/local-config';
+import { createBotDefinitionSyncService } from '../src/bot-definition/service';
+import { createBotDefinitionCloudSyncService } from '../src/bot-definition/cloud-sync';
+import { PromptReconcileCoordinator } from '../src/bot-definition/prompt-sync';
+import { BotDefinition, BotPromptDefinition } from '../src/bot-definition/types';
+
+describe('prompt skill cloud-first operations', () => {
+  let root: string;
+  let env: NodeJS.ProcessEnv;
+  let canonical: BotDefinition;
+  let revision: number;
+  let patches: number;
+  let patchStatus: number;
+  let readFailsAfterWrite: boolean;
+  let onPatch: (() => void) | undefined;
+  let fetchImpl: typeof fetch;
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'prompt-command-'));
+    const app = path.join(root, 'app');
+    fs.mkdirSync(path.join(app, 'prompts'), { recursive: true });
+    fs.writeFileSync(path.join(app, 'prompts/system-prompt.md'), 'Bundled v1\n');
+    env = { XIAOBA_APP_ROOT: app, XIAOBA_USER_DATA_DIR: root };
+    createCatsCoLocalConfigService({ runtimeRoot: root, env }).save({
+      version: 1,
+      account: { uid: '38', token: 'synthetic-owner-secret' },
+      currentBot: { uid: '982', apiKey: 'synthetic-bot-secret', boundByUserUid: '38', bindingSource: 'test' },
+      endpoints: { httpBaseUrl: 'https://example.invalid', serverUrl: 'wss://example.invalid/v0/channels' },
+    });
+    canonical = { schema: 'xiaoba.bot-definition.v1', botId: '982',
+      model: { kind: 'catalog', modelId: 'deepseek-v4-flash' }, prompt: { selected: 'default' } };
+    revision = 28; patches = 0; patchStatus = 200; readFailsAfterWrite = false; onPatch = undefined;
+    fetchImpl = (async (input, init) => {
+      if (init?.method === 'PATCH') {
+        patches++;
+        assert.equal(String(input), 'https://example.invalid/api/bots/definition/prompt?uid=982');
+        assert.equal((init.headers as any).Authorization, 'Bearer synthetic-owner-secret');
+        if (patchStatus !== 200) return Response.json({ error: 'synthetic-owner-secret' }, { status: patchStatus });
+        const payload = JSON.parse(String(init.body));
+        assert.deepEqual(Object.keys(payload).sort(), ['prompt', 'revision']);
+        assert.equal(payload.revision, revision);
+        canonical.prompt = payload.prompt;
+        revision++;
+        onPatch?.();
+        return Response.json({ revision });
+      }
+      assert.equal((init?.headers as any).Authorization, 'ApiKey synthetic-bot-secret');
+      if (readFailsAfterWrite && patches) throw new Error('synthetic-owner-secret');
+      return Response.json({ uid: 982, configured: true, revision, definition: canonical });
+    }) as typeof fetch;
+  });
+  afterEach(() => fs.rmSync(root, { recursive: true, force: true }));
+
+  const call = (args: string[]) => runPromptEditorCommand(args, { runtimeRoot: root, env, fetchImpl });
+  const active = () => path.join(root, 'prompt-overrides/system-prompt.md');
+  async function request(content?: string) {
+    const state = await call(['show']);
+    assert.equal(state.ok, true);
+    const file = path.join(root, 'request.json');
+    fs.writeFileSync(file, JSON.stringify({ botId: state.botId, expectedHash: state.expectedHash,
+      expectedRevision: state.expectedRevision, ...(content !== undefined ? { content } : {}) }));
+    return file;
+  }
+
+  test('show reads canonical selection without creating or changing runtime data', async () => {
+    const before = fs.readdirSync(root);
+    const state = await call(['show']);
+    assert.equal(state.selected, 'default');
+    assert.equal(state.content, 'Bundled v1');
+    assert.equal(state.localMatches, false);
+    assert.equal(state.cloudVerified, true);
+    assert.equal(state.expectedRevision, 28);
+    assert.deepEqual(fs.readdirSync(root), before);
+    assert.equal(patches, 0);
+  });
+
+  test('set, next-process load, reset and newer default preserve model, skills and custom draft', async () => {
+    const service = createBotDefinitionSyncService({ runtimeRoot: root, env });
+    service.acceptCanonical({ ...canonical, skills: [{ source: 'skillhub', skillId: 'user/demo', version: '1', contentHash: 'a'.repeat(64) }] });
+    const skills = service.read('982')!.skills;
+    const custom = 'My rules\n\nContinue tools until verified.\n';
+    const saved = await call(['set', await request(custom)]);
+    assert.equal(saved.ok, true);
+    assert.equal(saved.cloudWritten, true);
+    assert.equal(saved.localMatches, true);
+    assert.equal(saved.selected, 'custom');
+    assert.equal(saved.content, custom.trim());
+    assert.deepEqual(service.read('982')!.skills, skills);
+    assert.deepEqual(service.read('982')!.model, canonical.model);
+    const restarted = new PromptReconcileCoordinator({ runtimeRoot: root, env });
+    await restarted.activateBot('982', { preferDefinition: true });
+    assert.equal(fs.readFileSync(active(), 'utf8').trim(), custom.trim());
+    const reset = await call(['reset', await request()]);
+    assert.equal(reset.ok, true);
+    assert.equal(reset.selected, 'default');
+    assert.equal(reset.customContent, custom.trim());
+    assert.equal(reset.content, 'Bundled v1');
+    fs.writeFileSync(path.join(root, 'app/prompts/system-prompt.md'), 'Bundled v2\n');
+    await new PromptReconcileCoordinator({ runtimeRoot: root, env }).activateBot('982', { preferDefinition: true });
+    assert.equal((await call(['show'])).content, 'Bundled v2');
+    assert.equal((await call(['show'])).localMatches, true);
+    assert.equal(patches, 2);
+  });
+
+  test('refuses stale hashes, revisions and bot identity without writes', async () => {
+    for (const field of ['expectedHash', 'expectedRevision', 'botId']) {
+      const file = await request('new');
+      const value = JSON.parse(fs.readFileSync(file, 'utf8'));
+      value[field] = 'stale'; fs.writeFileSync(file, JSON.stringify(value));
+      assert.equal((await call(['set', file])).code, 'CONFLICT');
+    }
+    assert.equal(patches, 0); assert.equal(fs.existsSync(active()), false);
+  });
+
+  test('does not silently rebase a cloud conflict or expose raw upstream errors', async () => {
+    patchStatus = 409;
+    const result = await call(['set', await request('new')]);
+    assert.equal(result.ok, false); assert.equal(result.code, 'CONFLICT');
+    assert.equal(patches, 1); assert.equal(fs.existsSync(active()), false);
+    assert.ok(!JSON.stringify(result).includes('synthetic-owner-secret'));
+  });
+
+  test('unauthorized or unavailable cloud writes never change local prompt', async () => {
+    for (const status of [401, 403, 404, 500]) {
+      patchStatus = status;
+      const result = await call(['set', await request('new')]);
+      assert.equal(result.ok, false); assert.equal(result.cloudWritten, false);
+      assert.equal(fs.existsSync(active()), false);
+    }
+  });
+
+  test('refuses missing owner credentials before any write', async () => {
+    const config = createCatsCoLocalConfigService({ runtimeRoot: root, env });
+    const value = config.load(); value.account = undefined; config.save(value);
+    assert.equal((await call(['set', await request('new')])).code, 'OWNER_AUTH_REQUIRED');
+    assert.equal(patches, 0); assert.equal(fs.existsSync(active()), false);
+  });
+
+  test('reports cloud success with failed readback as partial, not local success', async () => {
+    readFailsAfterWrite = true;
+    const result = await call(['set', await request('new')]);
+    assert.equal(result.ok, false); assert.equal(result.cloudWritten, true);
+    assert.equal(canonical.prompt!.selected, 'custom');
+    assert.equal(fs.existsSync(active()), false);
+  });
+
+  test('does not materialize a prompt after the bot switches during cloud write', async () => {
+    onPatch = () => {
+      const config = createCatsCoLocalConfigService({ runtimeRoot: root, env });
+      const value = config.load(); value.currentBot!.uid = 'other-bot'; config.save(value);
+    };
+    const result = await call(['set', await request('new')]);
+    assert.equal(result.code, 'BOT_CHANGED'); assert.equal(result.cloudWritten, true);
+    assert.equal(fs.existsSync(active()), false);
+  });
+
+  test('preserves pending local edits instead of overwriting them', async () => {
+    createBotDefinitionCloudSyncService({ runtimeRoot: root, env }).markPromptPending('982');
+    assert.equal((await call(['set', await request('new')])).code, 'PENDING_LOCAL_EDIT');
+    assert.equal(patches, 0);
+  });
+
+  test('rejects empty, oversized, unexpected fields and reset content', async () => {
+    for (const content of ['', ' '.repeat(50), 'x'.repeat(256 * 1024 + 1)]) {
+      assert.equal((await call(['set', await request(content)])).code, 'INVALID_CONTENT');
+    }
+    assert.equal((await call(['reset', await request('bad')])).code, 'INVALID_REQUEST');
+    const file = await request('new');
+    const value = JSON.parse(fs.readFileSync(file, 'utf8')); value.path = '../runtime-context.md';
+    fs.writeFileSync(file, JSON.stringify(value));
+    assert.equal((await call(['set', file])).code, 'INVALID_REQUEST');
+    assert.equal(patches, 0);
+  });
+});

--- a/tests/runtime-factory.test.ts
+++ b/tests/runtime-factory.test.ts
@@ -76,7 +76,7 @@ describe('RuntimeFactory', () => {
 
     assert.deepStrictEqual(
       runtime.services.skillManager.getAllSkills().map(skill => skill.metadata.name),
-      ['factory-demo', 'xiaoba-knowledge'],
+      ['factory-demo', 'xiaoba-knowledge', 'catsco-prompt-editor'],
     );
   });
 

--- a/tests/skill-manager-atomic-load.test.ts
+++ b/tests/skill-manager-atomic-load.test.ts
@@ -135,5 +135,7 @@ function writeInvalidSkill(skillsPath: string, name: string): void {
 
 function skillNames(manager: SkillManager): string[] {
   assert.ok(manager.getSkill('xiaoba-knowledge'));
-  return manager.getAllSkills().map(skill => skill.metadata.name).filter(name => name !== 'xiaoba-knowledge').sort();
+  assert.ok(manager.getSkill('catsco-prompt-editor'));
+  return manager.getAllSkills().map(skill => skill.metadata.name)
+    .filter(name => !['xiaoba-knowledge', 'catsco-prompt-editor'].includes(name)).sort();
 }

--- a/tests/skill-tool-direct-content.test.ts
+++ b/tests/skill-tool-direct-content.test.ts
@@ -64,7 +64,7 @@ describe('skill tool direct content mode', () => {
     const result = await tool.execute({ skill: 'reload' }, {} as any);
 
     assert.equal(result.ok, true);
-    assert.match(String(result.content), /已重新加载 2 个 skills/);
+    assert.match(String(result.content), /已重新加载 3 个 skills/);
     assert.doesNotMatch(String(result.content), /__reload_skills__/);
   });
 

--- a/tests/turn-skill-snapshot.test.ts
+++ b/tests/turn-skill-snapshot.test.ts
@@ -183,7 +183,7 @@ describe('turn Skill snapshot store', () => {
       process.env.XIAOBA_SKILLS_DIR = secondRoot;
       await manager.reload();
 
-      assert.deepEqual(manager.getAllSkills().map(skill => skill.metadata.name), ['first-skill', 'xiaoba-knowledge']);
+      assert.deepEqual(manager.getAllSkills().map(skill => skill.metadata.name), ['first-skill', 'xiaoba-knowledge', 'catsco-prompt-editor']);
     } finally {
       if (previousSkillsDirectory === undefined) delete process.env.XIAOBA_SKILLS_DIR;
       else process.env.XIAOBA_SKILLS_DIR = previousSkillsDirectory;


### PR DESCRIPTION
## Summary

- Load the bundled `catsco-prompt-editor` alongside `xiaoba-knowledge`, including immutable turn snapshots, while preserving explicit same-name user overrides.
- Rewrite the old Skill for viewing, user-authorized customization and restoring the default main system prompt. The package-relative helper works without Dashboard and never outputs credentials.
- Bound bots use the existing cloud BotDefinition API as authority: revision/hash preconditions, owner authentication, no automatic conflict overwrite, cloud readback, local materialization and next-user-turn activation. Reset selects `default` and retains the custom draft. Unbound local instances retain local-only override behavior.
- Protect the bundled editor from Dashboard/CLI deletion. The legacy install endpoint now acknowledges availability without copying package-relative helpers into mutable user data or erasing custom files.

## Validation

- TypeScript compile and skill-creator validator passed.
- Latest-head focused regression: 117 passed, 2 existing POSIX-only shell tests skipped (119 total), including actual Skill → write_file → execute_shell → helper edit/reset.
- Packaged helper: four isolated CLI/Windows desktop/macOS bundle/Worker directory layouts, fresh subprocesses, UTF-8 paths and real HTTP requests against a synthetic cloud server; show/set/readback/reset passed. These are layout/transport tests on Windows, not native macOS or production tests.
- Cloud-first tests cover default/custom, restart-style rematerialization, upgraded bundled default, retained draft/model/Skills, stale identity/hash/revision, 409 without retry, permission/missing credentials, unavailable cloud, partial cloud success, active-bot switch, pending local edits, invalid/oversized content.
- Full Windows runtime run: 1886 total, 1867 passed, 2 failed, 17 skipped. Worker artifact test needs missing `jq` (reproduced at clean baseline `dd431f6`). The other failure is an intermittent Windows rename in the existing pending-evidence test; all 60 Bot Skill sync tests pass when rerun on this branch and clean baseline. Full local run is NOT claimed green.
- Linux CI run [34451427794](https://github.com/buildsense-ai/XiaoBa-CLI/actions/runs/34451427794) passed at head `dba627f871203cd8edc44e1c8bbba57c5d122b4d`: runtime 1879 passed / 0 failed / 8 skipped (1887 total); SkillHub regression 293 passed; paired BotDefinition Skills contract tests 65 passed. All four jobs are green, but the cross-repo smoke/e2e job skipped its actual smoke/e2e steps after script detection, so it is NOT executed E2E coverage.
- Real acceptance on 2026-09-10: branch Electron/Connector with the user's existing ck1 data and identity, GLM 5.3 Flash/max, actual production WebApp messages and cloud APIs. The model loaded the bundled Skill, preserved the full original prompt while appending the test rule, saved revision 2 -> 3, and verified cloud/local agreement. The next turn returned the expected marker and logged prompt hot reload; after connector restart a fresh conversation also returned the marker. The Skill reset to default at revision 4, retained the custom draft, and verified matching default content. One model-authored verification pipeline encountered a BOM parsing error and recovered using PowerShell parsing; helper save/reset succeeded.
- Post-test restoration removed the test draft and restored the original prompt selection/content. Knowledge file hashes, model selection and cloud Skills configuration were unchanged. The initially created disposable bot was deleted and confirmed absent, and its local credential copy was removed. Jack was not modified. This is local branch + live cloud/model acceptance, not acceptance of a newly published installer/Worker release.
- Additional review regression: 25 passed / 0 failed / 0 skipped. Latest PR head and base rechecked; user explicitly authorized admin merge after successful actual tests.

## Rollout / boundaries

- Admin merge explicitly authorized by the user for this PR after review/real acceptance. Releases still follow the existing tag-triggered workflow; no manual production upload.
- After release verify the editor is discoverable, then use an authorized disposable bot to confirm cloud selection/content, local materialization, next-turn prompt trace and restart persistence. Do not overwrite Jack's prompt to perform acceptance.
- If cloud save succeeds but local application/readback fails, the helper reports partial success; it does not blindly resubmit or roll back another concurrent edit.
