### PR TITLE
fix: isolate unchanged Skills from BotDefinition updates

### DIFF
--- a/src/bot-definition/activation.ts
+++ b/src/bot-definition/activation.ts
@@ -236,15 +236,16 @@ export async function prepareBoundBotDefinition(
         const reuseAppliedSkills = options.reuseAppliedSkills ?? Boolean(
           previouslyActiveDefinition
           && cloudSnapshot.definition
+          && cloudSnapshot.definition.skills !== undefined
           && botSkillRefsEqual(
             previouslyActiveDefinition.skills,
             cloudSnapshot.definition.skills,
           )
         );
+        const desiredRevision = cloudSnapshot.revision;
         const skillSync = (
           options.prepareSkills === false
           || options.preserveSkills
-          || reuseAppliedSkills
         )
           ? undefined
           : await prepareBoundBotSkills({
@@ -253,9 +254,16 @@ export async function prepareBoundBotDefinition(
               auth,
               fetchImpl: options.fetchImpl,
               definitionService,
+              ...(reuseAppliedSkills && cloudSnapshot.definition?.skills
+                ? {
+                    reuseVerifiedLocal: {
+                      skills: cloudSnapshot.definition.skills,
+                      definitionRevision: desiredRevision,
+                    },
+                  }
+                : {}),
             });
         definition = definitionService.read(botId) ?? definition;
-        const desiredRevision = cloudSnapshot.revision;
         const observedRevision = skillSync?.sync?.observedRevision ?? desiredRevision;
         const skillApplyStatus = skillSync?.sync?.applyStatus;
         const skippedSkillsAreAbsent = (
@@ -264,7 +272,6 @@ export async function prepareBoundBotDefinition(
         );
         const targetRevisionApplied = (
           options.preserveSkills
-          || reuseAppliedSkills
           || skippedSkillsAreAbsent
           || Boolean(
             skillSync
@@ -597,7 +604,6 @@ export async function prepareBoundBotDefinition(
   const skillSync = (
     options.prepareSkills === false
     || options.preserveSkills
-    || options.reuseAppliedSkills
     || (cloudSelection && !cloudSelection.definition)
   )
     ? undefined
@@ -607,6 +613,14 @@ export async function prepareBoundBotDefinition(
         auth,
         fetchImpl: options.fetchImpl,
         definitionService,
+        ...(options.reuseAppliedSkills && cloudSelection?.definition?.skills
+          ? {
+              reuseVerifiedLocal: {
+                skills: cloudSelection.definition.skills,
+                definitionRevision: cloudSelection.revision,
+              },
+            }
+          : {}),
       });
   const portableDefinition = definitionService.read(botId);
   if (portableDefinition) {

--- a/src/bot-definition/activation.ts
+++ b/src/bot-definition/activation.ts
@@ -15,6 +15,7 @@ import {
   SYSTEM_PROMPT_RELATIVE_PATH,
 } from '../utils/prompt-template';
 import { prepareBoundBotSkills, type PreparedBoundBotSkills } from '../bot-skills/runtime';
+import { botSkillRefsEqual } from '../bot-skills/canonical';
 import {
   catalogRuntimeMatchesModelId,
   createBotDefinitionSyncService,
@@ -48,6 +49,12 @@ export interface PrepareBoundBotDefinitionOptions extends BotDefinitionSyncServi
    * portion of a unified BotDefinition revision to become active.
    */
   preserveSkills?: boolean;
+  /**
+   * The desired Skill references are identical to the last locally active
+   * definition. Reuse that already-applied Skill dimension without scanning or
+   * mutating the workspace while a model/prompt-only revision is activated.
+   */
+  reuseAppliedSkills?: boolean;
   /** Hot reload must not silently fall back to legacy/local startup after a failed cloud read. */
   requireCloud?: boolean;
 }
@@ -88,6 +95,7 @@ export async function prepareBoundBotDefinition(
   }
   let sync = definitionService.pullOrBootstrap(botId);
   let localDefinition = sync?.definition;
+  const previouslyActiveDefinition = localDefinition;
   let initializedDefaultFromEmpty = false;
   const auth = options.auth ?? createCatsCoLocalConfigService({ runtimeRoot: options.runtimeRoot, env: options.env }).getAuthState();
   const cloudDefinitionSync = createBotDefinitionCloudSyncService({
@@ -225,7 +233,19 @@ export async function prepareBoundBotDefinition(
           cloudSnapshot = await cloudDefinitionSync.pushPrompt(botId, auth, definition.prompt)
             ?? cloudSnapshot;
         }
-        const skillSync = options.prepareSkills === false || options.preserveSkills
+        const reuseAppliedSkills = options.reuseAppliedSkills ?? Boolean(
+          previouslyActiveDefinition
+          && cloudSnapshot.definition
+          && botSkillRefsEqual(
+            previouslyActiveDefinition.skills,
+            cloudSnapshot.definition.skills,
+          )
+        );
+        const skillSync = (
+          options.prepareSkills === false
+          || options.preserveSkills
+          || reuseAppliedSkills
+        )
           ? undefined
           : await prepareBoundBotSkills({
               runtimeRoot: options.runtimeRoot,
@@ -242,12 +262,17 @@ export async function prepareBoundBotDefinition(
           options.prepareSkills === false
           && cloudSnapshot.definition?.skills === undefined
         );
-        const targetRevisionApplied = options.preserveSkills || skippedSkillsAreAbsent || Boolean(
-          skillSync
-          && (skillApplyStatus === 'applied' || skillApplyStatus === 'already_applied')
-          && skillSync.sync?.desiredRevision === desiredRevision
-          && skillSync.sync?.observedRevision === desiredRevision
-          && skillSync.sync?.appliedRevision === desiredRevision
+        const targetRevisionApplied = (
+          options.preserveSkills
+          || reuseAppliedSkills
+          || skippedSkillsAreAbsent
+          || Boolean(
+            skillSync
+            && (skillApplyStatus === 'applied' || skillApplyStatus === 'already_applied')
+            && skillSync.sync?.desiredRevision === desiredRevision
+            && skillSync.sync?.observedRevision === desiredRevision
+            && skillSync.sync?.appliedRevision === desiredRevision
+          )
         );
         const appliedRevision = targetRevisionApplied ? desiredRevision : undefined;
         const cloudApplyError = targetRevisionApplied
@@ -572,6 +597,7 @@ export async function prepareBoundBotDefinition(
   const skillSync = (
     options.prepareSkills === false
     || options.preserveSkills
+    || options.reuseAppliedSkills
     || (cloudSelection && !cloudSelection.definition)
   )
     ? undefined

--- a/src/bot-skills/runtime.ts
+++ b/src/bot-skills/runtime.ts
@@ -21,6 +21,7 @@ import {
   BotSkillWorkspaceService,
   type BotSkillWorkspaceActivation,
 } from './workspace';
+import type { BotSkillRef } from '../bot-definition/types';
 
 export interface PrepareBoundBotSkillsOptions {
   runtimeRoot: string;
@@ -28,6 +29,14 @@ export interface PrepareBoundBotSkillsOptions {
   auth: CatsCoAuthSnapshot;
   fetchImpl?: typeof fetch;
   definitionService: BotDefinitionSyncService;
+  /**
+   * Reuse is allowed only after workspace ownership, Base metadata, and local
+   * package hashes are verified under the normal cross-process Skill lock.
+   */
+  reuseVerifiedLocal?: {
+    skills: readonly BotSkillRef[];
+    definitionRevision: number;
+  };
 }
 
 export interface PreparedBoundBotSkills {
@@ -108,7 +117,7 @@ export async function prepareBoundBotSkills(
         BotSkillSyncService.recoverInterruptedRestore(runtimeRoot, activeBotId, activeRoot);
       }
       activation = workspace.activate(options.botId);
-      const sync = await new BotSkillSyncService({
+      const syncService = new BotSkillSyncService({
         runtimeRoot,
         botId: options.botId,
         auth: options.auth,
@@ -116,7 +125,14 @@ export async function prepareBoundBotSkills(
         workspaceExisted: activation.existed,
         fetchImpl: options.fetchImpl,
         definitionService: options.definitionService,
-      }).reconcileActivationFromCloudOnly();
+      });
+      const reused = options.reuseVerifiedLocal
+        ? syncService.reuseVerifiedActivation(
+            options.reuseVerifiedLocal.skills,
+            options.reuseVerifiedLocal.definitionRevision,
+          )
+        : undefined;
+      const sync = reused ?? await syncService.reconcileActivationFromCloudOnly();
       return { sync, workspaceExisted: activation.existed, activation };
     } catch (error) {
       const failure = error instanceof BotSkillCloudRestoreError

--- a/src/bot-skills/sync-service.ts
+++ b/src/bot-skills/sync-service.ts
@@ -29,6 +29,7 @@ import {
 } from './local-manifest';
 import { BotPrivateSkillClient } from './private-package-client';
 import { renameBotSkillWorkspaceSync } from './workspace-fs';
+import { BotSkillWorkspaceService } from './workspace';
 import type {
   BotSkillPackage,
   BotSkillPackageFile,
@@ -470,6 +471,64 @@ export class BotSkillSyncService {
         { cause: error },
       );
     }
+  }
+
+  /**
+   * Reuses an unchanged Skill dimension without reading packages from Cloud.
+   * Equality in BotDefinition alone is insufficient: this also proves that the
+   * selected Bot owns the active workspace and that every local package still
+   * matches its verified Base entry. Returning undefined deliberately falls
+   * through to the strict Cloud-only activation path.
+   */
+  reuseVerifiedActivation(
+    expectedSkills: readonly BotSkillRef[],
+    definitionRevision: number,
+  ): BotSkillSyncResult | undefined {
+    if (!Number.isInteger(definitionRevision) || definitionRevision < 0) {
+      throw new Error('Bot Skill reuse requires a valid Definition revision.');
+    }
+    BotSkillSyncService.recoverInterruptedRestore(
+      this.runtimeRoot,
+      this.botId,
+      this.skillsRoot,
+    );
+    const workspace = new BotSkillWorkspaceService(this.runtimeRoot, this.skillsRoot);
+    workspace.recoverInterruptedSwitch();
+    if (workspace.getActiveBotId() !== this.botId) return undefined;
+    const base = this.baseStore.read(this.botId);
+    if (!this.workspaceExisted || !base || !fs.existsSync(this.skillsRoot)) return undefined;
+
+    let local: LocalBotSkillManifestEntry[];
+    try {
+      local = this.readLocalManifest({ writeMarkers: false });
+    } catch {
+      return undefined;
+    }
+    const canonicalSkills = canonicalizeBotSkillRefs(expectedSkills);
+    if (
+      !localMatchesBase(local, base)
+      || !botSkillRefsEqual(canonicalSkills, base.skills.map(entry => entry.reference))
+    ) {
+      return undefined;
+    }
+
+    if (base.definitionRevision !== definitionRevision) {
+      this.baseStore.write({
+        ...base,
+        definitionRevision,
+        updatedAt: new Date().toISOString(),
+      });
+    }
+    return {
+      botId: this.botId,
+      direction: 'none',
+      cloudRevision: definitionRevision,
+      observedRevision: definitionRevision,
+      desiredRevision: definitionRevision,
+      appliedRevision: definitionRevision,
+      applyStatus: 'already_applied',
+      skills: canonicalSkills,
+    };
   }
 
   /**

--- a/src/commands/catscompany.ts
+++ b/src/commands/catscompany.ts
@@ -471,11 +471,11 @@ async function applyCloudBotDefinitionSelection(
     && effectiveIncoming.skills !== undefined
     && botSkillRefsEqual(previousDefinition.skills, effectiveIncoming.skills)
   );
-  const modelChanged = !previousDefinition
+  const queuedModelChanged = !previousDefinition
     || !effectiveIncoming
     || JSON.stringify(previousDefinition.model) !== JSON.stringify(effectiveIncoming.model);
 
-  if (modelChanged && (!options.canApply() || !options.currentBot().isIdleForRuntimeReload())) {
+  if (queuedModelChanged && (!options.canApply() || !options.currentBot().isIdleForRuntimeReload())) {
     return 'deferred';
   }
 
@@ -555,13 +555,19 @@ async function applyCloudBotDefinitionSelection(
     definition: prepared.definition,
   };
 
-  if (!modelChanged) {
+  const appliedModelChanged = !previousDefinition
+    || JSON.stringify(previousDefinition.model) !== JSON.stringify(prepared.definition.model);
+  if (!appliedModelChanged) {
     await acknowledgeCloudModelApply(options, '', appliedSelection);
     Logger.success(`CatsCo applied BotDefinition revision=${appliedSelection.revision} without restarting the connector.`);
     return 'applied';
   }
 
   const previousBot = options.currentBot();
+  if (!options.canApply() || !previousBot.isIdleForRuntimeReload()) {
+    restorePreviousRuntime(true);
+    return 'deferred';
+  }
   let nextBot: CatsCompanyBot | undefined;
   try {
     await previousBot.destroy();
@@ -593,8 +599,11 @@ async function applyCloudBotDefinitionSelection(
   }
 
   await acknowledgeCloudModelApply(options, '', appliedSelection);
+  const appliedModelId = prepared.definition.model.kind === 'custom'
+    ? prepared.definition.model.model
+    : prepared.definition.model.modelId;
   Logger.success(
-    `CatsCo applied BotDefinition model ${options.selection.modelId}, revision=${options.selection.revision}.`,
+    `CatsCo applied BotDefinition model ${appliedModelId}, revision=${appliedSelection.revision}.`,
   );
   return 'applied';
 }

--- a/src/commands/catscompany.ts
+++ b/src/commands/catscompany.ts
@@ -468,6 +468,7 @@ async function applyCloudBotDefinitionSelection(
   const reuseAppliedSkills = Boolean(
     previousDefinition
     && effectiveIncoming
+    && effectiveIncoming.skills !== undefined
     && botSkillRefsEqual(previousDefinition.skills, effectiveIncoming.skills)
   );
   const modelChanged = !previousDefinition

--- a/src/commands/catscompany.ts
+++ b/src/commands/catscompany.ts
@@ -36,6 +36,7 @@ import {
   assertOperatorManagedSkillWorkspaceBinding,
   preserveOperatorManagedSkills,
 } from '../bot-skills/preservation';
+import { botSkillRefsEqual } from '../bot-skills/canonical';
 
 const CONNECTOR_OWNER_POLL_MS = 2000;
 const CLOUD_MODEL_POLL_MS = 5000;
@@ -464,6 +465,11 @@ async function applyCloudBotDefinitionSelection(
   });
   const previousPrompt = promptCoordinator.captureActiveSnapshot();
   const effectiveIncoming = resolveRunnableCloudDefinition(incoming, previousDefinition);
+  const reuseAppliedSkills = Boolean(
+    previousDefinition
+    && effectiveIncoming
+    && botSkillRefsEqual(previousDefinition.skills, effectiveIncoming.skills)
+  );
   const modelChanged = !previousDefinition
     || !effectiveIncoming
     || JSON.stringify(previousDefinition.model) !== JSON.stringify(effectiveIncoming.model);
@@ -483,12 +489,14 @@ async function applyCloudBotDefinitionSelection(
     return 'deferred';
   }
 
-  const restorePreviousRuntime = () => {
+  const restorePreviousRuntime = (preservePreparedSkills = false) => {
     if (previousDefinition) {
-      const activeSkills = definitionService.read(options.botId)?.skills;
+      const activeSkills = preservePreparedSkills
+        ? definitionService.read(options.botId)?.skills
+        : undefined;
       definitionService.acceptCanonical({
         ...previousDefinition,
-        ...(activeSkills !== undefined ? { skills: activeSkills } : {}),
+        ...(preservePreparedSkills && activeSkills !== undefined ? { skills: activeSkills } : {}),
       });
     }
     if (previousCatalogRuntime) definitionService.storeCatalogRuntime(previousCatalogRuntime);
@@ -507,6 +515,7 @@ async function applyCloudBotDefinitionSelection(
       auth: options.auth,
       acknowledgeCloudSelection: false,
       preserveSkills,
+      reuseAppliedSkills,
       requireCloud: true,
     });
   } catch (error) {
@@ -518,7 +527,7 @@ async function applyCloudBotDefinitionSelection(
   }
 
   if (!options.canApply()) {
-    restorePreviousRuntime();
+    restorePreviousRuntime(true);
     return 'deferred';
   }
 
@@ -555,13 +564,13 @@ async function applyCloudBotDefinitionSelection(
   let nextBot: CatsCompanyBot | undefined;
   try {
     await previousBot.destroy();
-    if (!options.canApply()) { restorePreviousRuntime(); return 'deferred'; }
+    if (!options.canApply()) { restorePreviousRuntime(true); return 'deferred'; }
     nextBot = new CatsCompanyBot(options.connectorConfig);
     await nextBot.start();
     await nextBot.waitUntilReady();
     if (!options.canApply()) {
       await nextBot.destroy();
-      restorePreviousRuntime();
+      restorePreviousRuntime(true);
       return 'deferred';
     }
     options.replaceBot(nextBot);
@@ -571,7 +580,7 @@ async function applyCloudBotDefinitionSelection(
         Logger.warning(`Failed to clean up an unstarted CatsCo connector: ${errorMessage(cleanupError)}`);
       });
     }
-    restorePreviousRuntime();
+    restorePreviousRuntime(true);
     const message = redactCloudBotModelError(error, options.selection);
     await acknowledgeCloudModelApply(options, message, appliedSelection);
     await recoverCloudModelFallbackConnector({

--- a/tests/bot-skill-preservation.test.ts
+++ b/tests/bot-skill-preservation.test.ts
@@ -5,13 +5,15 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { prepareBoundBotDefinition } from '../src/bot-definition/activation';
 import { createBotDefinitionSyncService } from '../src/bot-definition/service';
-import { BOT_DEFINITION_SCHEMA } from '../src/bot-definition/types';
+import { BOT_DEFINITION_SCHEMA, type BotSkillRef } from '../src/bot-definition/types';
 import { createCatsCoLocalConfigService } from '../src/catscompany/local-config';
 import {
   assertOperatorManagedSkillWorkspaceBinding,
   preserveOperatorManagedSkills,
 } from '../src/bot-skills/preservation';
 import { BotSkillWorkspaceService } from '../src/bot-skills/workspace';
+import { BotSkillBaseStore } from '../src/bot-skills/base-store';
+import { scanBotSkillWorkspace } from '../src/bot-skills/local-manifest';
 
 describe('operator-managed Skill workspace preservation', () => {
   test('is disabled by default', () => {
@@ -153,7 +155,7 @@ describe('operator-managed Skill workspace preservation', () => {
           contextWindowTokens: 128000,
         },
         prompt: { selected: 'custom' as const, customSystemPrompt: 'Unchanged prompt.' },
-        skills: [],
+        skills: [TEST_SKILL_REFERENCE],
       };
       const desired = {
         ...previous,
@@ -172,6 +174,7 @@ describe('operator-managed Skill workspace preservation', () => {
         'Keep this content.',
         '',
       ].join('\n'));
+      writeVerifiedSkillBase(runtimeRoot, 'bot-43', 6, TEST_SKILL_REFERENCE);
       const before = snapshotDirectory(path.join(runtimeRoot, 'skills'));
       const requests: string[] = [];
       const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
@@ -195,7 +198,7 @@ describe('operator-managed Skill workspace preservation', () => {
 
       assert.equal(prepared?.botId, 'bot-43');
       assert.equal(prepared?.cloudRevision, 7);
-      assert.equal(prepared?.skillSync, undefined);
+      assert.equal(prepared?.skillSync?.sync?.applyStatus, 'already_applied');
       assert.deepStrictEqual(snapshotDirectory(path.join(runtimeRoot, 'skills')), before);
       assert.equal(requests.some(request => request.includes('/api/bot/definition/skills')), false);
       assert.deepStrictEqual(prepared?.definition.model, desired.model);
@@ -205,6 +208,36 @@ describe('operator-managed Skill workspace preservation', () => {
     }
   });
 });
+
+const TEST_SKILL_REFERENCE: BotSkillRef = {
+  source: 'skillhub',
+  skillId: 'private/server-local',
+  version: 'sha256-server-local',
+  contentHash: 'a'.repeat(64),
+};
+
+function writeVerifiedSkillBase(
+  runtimeRoot: string,
+  botId: string,
+  definitionRevision: number,
+  reference: BotSkillRef,
+): void {
+  const local = scanBotSkillWorkspace(path.join(runtimeRoot, 'skills'), { writeMarkers: false });
+  assert.equal(local.length, 1);
+  new BotSkillBaseStore(runtimeRoot).write({
+    schema: 'xiaoba.bot-skill-sync-base.v2',
+    botId,
+    definitionRevision,
+    skills: local.map(entry => ({
+      localSkillId: entry.localSkillId,
+      name: entry.name,
+      installName: entry.installName,
+      contentHash: entry.contentHash,
+      reference,
+    })),
+    updatedAt: new Date().toISOString(),
+  });
+}
 
 function snapshotDirectory(root: string): Array<[string, string]> {
   const snapshot: Array<[string, string]> = [];

--- a/tests/bot-skill-preservation.test.ts
+++ b/tests/bot-skill-preservation.test.ts
@@ -123,6 +123,87 @@ describe('operator-managed Skill workspace preservation', () => {
       fs.rmSync(runtimeRoot, { recursive: true, force: true });
     }
   });
+
+  test('reuses unchanged Skill references for model/prompt startup updates without touching the workspace', async () => {
+    const runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xiaoba-unchanged-skills-startup-'));
+    try {
+      createCatsCoLocalConfigService({ runtimeRoot }).save({
+        version: 1,
+        endpoints: {
+          httpBaseUrl: 'https://cats.example.test',
+          serverUrl: 'wss://cats.example.test/v0/channels',
+        },
+        account: { token: 'owner-token', uid: 'owner-7' },
+        currentBot: {
+          uid: 'bot-43',
+          apiKey: 'bot-api-key',
+          boundByUserUid: 'owner-7',
+          bindingSource: 'test',
+        },
+      });
+      const previous = {
+        schema: BOT_DEFINITION_SCHEMA,
+        botId: 'bot-43',
+        model: {
+          kind: 'custom' as const,
+          protocol: 'openai-responses' as const,
+          apiBase: 'https://models.example.test/v1',
+          model: 'previous-model',
+          apiKey: 'test-model-key',
+          contextWindowTokens: 128000,
+        },
+        prompt: { selected: 'custom' as const, customSystemPrompt: 'Unchanged prompt.' },
+        skills: [],
+      };
+      const desired = {
+        ...previous,
+        model: { ...previous.model, model: 'next-model' },
+        prompt: { selected: 'custom' as const, customSystemPrompt: 'Updated prompt.' },
+      };
+      createBotDefinitionSyncService({ runtimeRoot }).acceptCanonical(previous);
+      const skillRoot = path.join(runtimeRoot, 'skills', 'server-local');
+      fs.mkdirSync(skillRoot, { recursive: true });
+      fs.writeFileSync(path.join(skillRoot, 'SKILL.md'), [
+        '---',
+        'name: server-local',
+        'description: Server-local Skill that startup must leave unchanged.',
+        '---',
+        '',
+        'Keep this content.',
+        '',
+      ].join('\n'));
+      const before = snapshotDirectory(path.join(runtimeRoot, 'skills'));
+      const requests: string[] = [];
+      const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
+        const url = new URL(String(input));
+        const method = init?.method || 'GET';
+        requests.push(`${method} ${url.pathname}`);
+        if (url.pathname === '/api/bot/definition' && method === 'GET') {
+          return Response.json({ configured: true, revision: 7, definition: desired });
+        }
+        if (url.pathname === '/api/bot/definition/default-prompt') {
+          return Response.json({ status: 'stored' });
+        }
+        throw new Error(`Unexpected test request: ${method} ${url.pathname}`);
+      }) as typeof fetch;
+
+      const prepared = await prepareBoundBotDefinition({
+        runtimeRoot,
+        fetchImpl,
+        acknowledgeCloudSelection: false,
+      });
+
+      assert.equal(prepared?.botId, 'bot-43');
+      assert.equal(prepared?.cloudRevision, 7);
+      assert.equal(prepared?.skillSync, undefined);
+      assert.deepStrictEqual(snapshotDirectory(path.join(runtimeRoot, 'skills')), before);
+      assert.equal(requests.some(request => request.includes('/api/bot/definition/skills')), false);
+      assert.deepStrictEqual(prepared?.definition.model, desired.model);
+      assert.deepStrictEqual(prepared?.definition.prompt, desired.prompt);
+    } finally {
+      fs.rmSync(runtimeRoot, { recursive: true, force: true });
+    }
+  });
 });
 
 function snapshotDirectory(root: string): Array<[string, string]> {

--- a/tests/cloud-bot-model-apply-retry.test.ts
+++ b/tests/cloud-bot-model-apply-retry.test.ts
@@ -118,6 +118,186 @@ test('post-start BotDefinition updates preserve an operator-managed Skill worksp
   assert.deepEqual(definitions.read('43')?.prompt, desired.prompt);
 });
 
+test('post-start model-only updates reuse unchanged Skills without touching the workspace', async t => {
+  const runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'model-apply-unchanged-skills-'));
+  t.after(() => fs.rmSync(runtimeRoot, { recursive: true, force: true }));
+  const configService = createCatsCoLocalConfigService({ runtimeRoot });
+  configService.save({
+    version: 1,
+    endpoints: { httpBaseUrl: 'https://cats.example.test', serverUrl: 'wss://cats.example.test/v0/channels' },
+    account: { token: 'test-owner-token', uid: '7' },
+    currentBot: { uid: '43', apiKey: 'test-bot-key', boundByUserUid: '7', bindingSource: 'test' },
+  });
+  const auth = configService.getAuthState();
+  const definitions = createBotDefinitionSyncService({ runtimeRoot });
+  const previous: BotDefinition = {
+    schema: BOT_DEFINITION_SCHEMA,
+    botId: '43',
+    model: {
+      kind: 'custom', protocol: 'openai-responses', apiBase: 'https://models.example.test/v1',
+      model: 'previous-model', apiKey: 'test-model-key', contextWindowTokens: 128000,
+    },
+    prompt: { selected: 'custom', customSystemPrompt: 'Unchanged prompt.' },
+    skills: [],
+  };
+  const desired: BotDefinition = {
+    ...previous,
+    model: { ...previous.model, model: 'next-model' },
+  };
+  definitions.acceptCanonical(previous);
+  const localSkillRoot = path.join(runtimeRoot, 'skills', 'server-local');
+  const localSkillFile = path.join(localSkillRoot, 'SKILL.md');
+  fs.mkdirSync(localSkillRoot, { recursive: true });
+  fs.writeFileSync(localSkillFile, [
+    '---',
+    'name: server-local',
+    'description: Server-local Skill that a model-only update must not reconcile.',
+    '---',
+    '',
+    'Keep this content.',
+    '',
+  ].join('\n'));
+  const before = fs.readFileSync(localSkillFile, 'utf8');
+  const requests: string[] = [];
+  const acks: unknown[] = [];
+  t.mock.method(globalThis, 'fetch', async (input: string | URL | Request, init?: RequestInit) => {
+    const url = new URL(String(input));
+    const method = init?.method || 'GET';
+    requests.push(`${method} ${url.pathname}`);
+    if (url.pathname === '/api/bot/definition' && method === 'GET') {
+      return Response.json({ configured: true, revision: 7, definition: desired });
+    }
+    if (url.pathname === '/api/bot/definition/ack' && method === 'POST') {
+      acks.push(JSON.parse(String(init?.body)));
+      return Response.json({ status: 'applied' });
+    }
+    if (url.pathname === '/api/bot/definition/default-prompt') {
+      return Response.json({ status: 'stored' });
+    }
+    throw new Error(`Unexpected test request: ${method} ${url.pathname}`);
+  });
+  let stopped = 0;
+  let started = 0;
+  const oldBot = {
+    isIdleForRuntimeReload: () => true,
+    destroy: async () => { stopped += 1; },
+  } as CatsCompanyBot;
+  let bot = oldBot;
+  t.mock.method(CatsCompanyBot.prototype, 'start', async function (this: CatsCompanyBot) {
+    started += 1;
+    t.after(() => this.destroy());
+  });
+  t.mock.method(CatsCompanyBot.prototype, 'waitUntilReady', async () => {});
+
+  const result = await applyCloudModelRuntimeSelection({
+    runtimeRoot,
+    botId: '43',
+    auth,
+    selection: {
+      kind: 'custom',
+      modelId: 'next-model',
+      customModel: desired.model,
+      revision: 7,
+      definition: desired,
+    },
+    canApply: () => true,
+    connectorConfig: {
+      serverUrl: 'wss://cats.example.test/v0/channels',
+      apiKey: 'test-bot-key',
+      botUid: '43',
+    },
+    currentBot: () => bot,
+    replaceBot: next => { bot = next; },
+    scheduleAckRetry: () => assert.fail('ACK should succeed'),
+    clearAckRetry: () => {},
+  });
+
+  assert.equal(result, 'applied');
+  assert.equal(stopped, 1);
+  assert.equal(started, 1);
+  assert.notEqual(bot, oldBot);
+  assert.deepEqual(acks, [{ revision: 7 }]);
+  assert.equal(requests.some(request => request.includes('/api/bot/definition/skills')), false);
+  assert.equal(requests.some(request => request.includes('private-skill-packages')), false);
+  assert.equal(fs.readFileSync(localSkillFile, 'utf8'), before);
+  assert.deepEqual(definitions.read('43')?.model, desired.model);
+});
+
+test('post-start prompt-only updates reuse unchanged Skills without restarting the connector', async t => {
+  const runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'prompt-apply-unchanged-skills-'));
+  t.after(() => fs.rmSync(runtimeRoot, { recursive: true, force: true }));
+  const configService = createCatsCoLocalConfigService({ runtimeRoot });
+  configService.save({
+    version: 1,
+    endpoints: { httpBaseUrl: 'https://cats.example.test', serverUrl: 'wss://cats.example.test/v0/channels' },
+    account: { token: 'test-owner-token', uid: '7' },
+    currentBot: { uid: '43', apiKey: 'test-bot-key', boundByUserUid: '7', bindingSource: 'test' },
+  });
+  const auth = configService.getAuthState();
+  const definitions = createBotDefinitionSyncService({ runtimeRoot });
+  const previous: BotDefinition = {
+    schema: BOT_DEFINITION_SCHEMA,
+    botId: '43',
+    model: {
+      kind: 'custom', protocol: 'openai-responses', apiBase: 'https://models.example.test/v1',
+      model: 'unchanged-model', apiKey: 'test-model-key', contextWindowTokens: 128000,
+    },
+    prompt: { selected: 'custom', customSystemPrompt: 'Previous prompt.' },
+    skills: [],
+  };
+  const desired: BotDefinition = {
+    ...previous,
+    prompt: { selected: 'custom', customSystemPrompt: 'Updated prompt.' },
+  };
+  definitions.acceptCanonical(previous);
+  const localSkillRoot = path.join(runtimeRoot, 'skills', 'server-local');
+  fs.mkdirSync(localSkillRoot, { recursive: true });
+  fs.writeFileSync(path.join(localSkillRoot, 'SKILL.md'), 'operator content\n');
+  const requests: string[] = [];
+  const acks: unknown[] = [];
+  t.mock.method(globalThis, 'fetch', async (input: string | URL | Request, init?: RequestInit) => {
+    const url = new URL(String(input));
+    const method = init?.method || 'GET';
+    requests.push(`${method} ${url.pathname}`);
+    if (url.pathname === '/api/bot/definition' && method === 'GET') {
+      return Response.json({ configured: true, revision: 7, definition: desired });
+    }
+    if (url.pathname === '/api/bot/definition/ack' && method === 'POST') {
+      acks.push(JSON.parse(String(init?.body)));
+      return Response.json({ status: 'applied' });
+    }
+    if (url.pathname === '/api/bot/definition/default-prompt') {
+      return Response.json({ status: 'stored' });
+    }
+    throw new Error(`Unexpected test request: ${method} ${url.pathname}`);
+  });
+  const oldBot = { isIdleForRuntimeReload: () => true } as CatsCompanyBot;
+
+  const result = await applyCloudModelRuntimeSelection({
+    runtimeRoot,
+    botId: '43',
+    auth,
+    selection: {
+      kind: 'custom', modelId: 'unchanged-model', customModel: desired.model,
+      revision: 7, definition: desired,
+    },
+    canApply: () => true,
+    connectorConfig: {
+      serverUrl: 'wss://cats.example.test/v0/channels', apiKey: 'test-bot-key', botUid: '43',
+    },
+    currentBot: () => oldBot,
+    replaceBot: () => assert.fail('prompt-only update must not replace the connector'),
+    scheduleAckRetry: () => assert.fail('ACK should succeed'),
+    clearAckRetry: () => {},
+  });
+
+  assert.equal(result, 'applied');
+  assert.deepEqual(acks, [{ revision: 7 }]);
+  assert.equal(requests.some(request => request.includes('/api/bot/definition/skills')), false);
+  assert.equal(fs.readFileSync(path.join(localSkillRoot, 'SKILL.md'), 'utf8'), 'operator content\n');
+  assert.deepEqual(definitions.read('43')?.prompt, desired.prompt);
+});
+
 for (const failure of [502, 503, 504, 429, 'timeout', 'reset', 'shutdown'] as const) {
 for (const failureRead of [3, 4]) {
 test(`cloud recheck ${failure} at read ${failureRead} preserves the old connector`, async t => {
@@ -138,10 +318,10 @@ test(`cloud recheck ${failure} at read ${failureRead} preserves the old connecto
       kind: 'custom', protocol: 'openai-responses', apiBase: 'https://models.example.test/v1',
       apiKey: 'test-model-key', model: 'previous-model', contextWindowTokens: 128000,
     },
-    prompt: { selected: 'custom', customSystemPrompt: 'Test prompt.' }, skills: [],
+    prompt: { selected: 'custom', customSystemPrompt: 'Test prompt.' },
   };
   definitions.acceptCanonical(previous);
-  const desired = { ...previous, model: { ...previous.model, model: 'next-model' } };
+  const desired = { ...previous, model: { ...previous.model, model: 'next-model' }, skills: [] };
   fs.mkdirSync(path.join(runtimeRoot, 'skills'), { recursive: true });
   new BotSkillBaseStore(runtimeRoot).write({
     schema: 'xiaoba.bot-skill-sync-base.v2', botId: '43', definitionRevision: 6,

--- a/tests/cloud-bot-model-apply-retry.test.ts
+++ b/tests/cloud-bot-model-apply-retry.test.ts
@@ -11,6 +11,9 @@ import { CloudBotModelRuntimeReloadController } from '../src/bot-definition/runt
 import { createBotDefinitionSyncService } from '../src/bot-definition/service';
 import { BOT_DEFINITION_SCHEMA, type BotDefinition } from '../src/bot-definition/types';
 import { BotSkillBaseStore } from '../src/bot-skills/base-store';
+import { scanBotSkillWorkspace } from '../src/bot-skills/local-manifest';
+import { BotSkillWorkspaceService } from '../src/bot-skills/workspace';
+import type { BotSkillRef } from '../src/bot-definition/types';
 
 test('post-start BotDefinition updates preserve an operator-managed Skill workspace', async t => {
   const runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'model-apply-preserved-skills-'));
@@ -118,7 +121,7 @@ test('post-start BotDefinition updates preserve an operator-managed Skill worksp
   assert.deepEqual(definitions.read('43')?.prompt, desired.prompt);
 });
 
-test('post-start model-only updates reuse unchanged Skills without touching the workspace', async t => {
+test('post-start model-only updates restore B after B -> A -> B and reuse its verified Skills', async t => {
   const runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'model-apply-unchanged-skills-'));
   t.after(() => fs.rmSync(runtimeRoot, { recursive: true, force: true }));
   const configService = createCatsCoLocalConfigService({ runtimeRoot });
@@ -138,7 +141,7 @@ test('post-start model-only updates reuse unchanged Skills without touching the 
       model: 'previous-model', apiKey: 'test-model-key', contextWindowTokens: 128000,
     },
     prompt: { selected: 'custom', customSystemPrompt: 'Unchanged prompt.' },
-    skills: [],
+    skills: [TEST_SKILL_REFERENCE],
   };
   const desired: BotDefinition = {
     ...previous,
@@ -157,7 +160,13 @@ test('post-start model-only updates reuse unchanged Skills without touching the 
     'Keep this content.',
     '',
   ].join('\n'));
+  writeVerifiedSkillBase(runtimeRoot, '43', 6, TEST_SKILL_REFERENCE);
   const before = fs.readFileSync(localSkillFile, 'utf8');
+  const workspace = new BotSkillWorkspaceService(runtimeRoot);
+  workspace.activate('43');
+  workspace.activate('other-bot');
+  fs.mkdirSync(path.join(runtimeRoot, 'skills', 'other-local'), { recursive: true });
+  fs.writeFileSync(path.join(runtimeRoot, 'skills', 'other-local', 'SKILL.md'), 'other bot content\n');
   const requests: string[] = [];
   const acks: unknown[] = [];
   t.mock.method(globalThis, 'fetch', async (input: string | URL | Request, init?: RequestInit) => {
@@ -217,9 +226,12 @@ test('post-start model-only updates reuse unchanged Skills without touching the 
   assert.equal(started, 1);
   assert.notEqual(bot, oldBot);
   assert.deepEqual(acks, [{ revision: 7 }]);
+  assert.equal(requests.filter(request => request === 'GET /api/bot/definition').length, 2);
   assert.equal(requests.some(request => request.includes('/api/bot/definition/skills')), false);
   assert.equal(requests.some(request => request.includes('private-skill-packages')), false);
   assert.equal(fs.readFileSync(localSkillFile, 'utf8'), before);
+  assert.equal(workspace.getActiveBotId(), '43');
+  assert.equal(fs.existsSync(path.join(runtimeRoot, 'skills', 'other-local')), false);
   assert.deepEqual(definitions.read('43')?.model, desired.model);
 });
 
@@ -243,7 +255,7 @@ test('post-start prompt-only updates reuse unchanged Skills without restarting t
       model: 'unchanged-model', apiKey: 'test-model-key', contextWindowTokens: 128000,
     },
     prompt: { selected: 'custom', customSystemPrompt: 'Previous prompt.' },
-    skills: [],
+    skills: [TEST_SKILL_REFERENCE],
   };
   const desired: BotDefinition = {
     ...previous,
@@ -253,6 +265,7 @@ test('post-start prompt-only updates reuse unchanged Skills without restarting t
   const localSkillRoot = path.join(runtimeRoot, 'skills', 'server-local');
   fs.mkdirSync(localSkillRoot, { recursive: true });
   fs.writeFileSync(path.join(localSkillRoot, 'SKILL.md'), 'operator content\n');
+  writeVerifiedSkillBase(runtimeRoot, '43', 6, TEST_SKILL_REFERENCE);
   const requests: string[] = [];
   const acks: unknown[] = [];
   t.mock.method(globalThis, 'fetch', async (input: string | URL | Request, init?: RequestInit) => {
@@ -297,6 +310,108 @@ test('post-start prompt-only updates reuse unchanged Skills without restarting t
   assert.equal(fs.readFileSync(path.join(localSkillRoot, 'SKILL.md'), 'utf8'), 'operator content\n');
   assert.deepEqual(definitions.read('43')?.prompt, desired.prompt);
 });
+
+for (const workspaceCase of ['missing', 'corrupt'] as const) {
+test(`unchanged Skill refs do not bypass strict activation for a ${workspaceCase} workspace`, async t => {
+  const runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), `model-apply-${workspaceCase}-skills-`));
+  t.after(() => fs.rmSync(runtimeRoot, { recursive: true, force: true }));
+  const configService = createCatsCoLocalConfigService({ runtimeRoot });
+  configService.save({
+    version: 1,
+    endpoints: { httpBaseUrl: 'https://cats.example.test', serverUrl: 'wss://cats.example.test/v0/channels' },
+    account: { token: 'test-owner-token', uid: '7' },
+    currentBot: { uid: '43', apiKey: 'test-bot-key', boundByUserUid: '7', bindingSource: 'test' },
+  });
+  const auth = configService.getAuthState();
+  const definitions = createBotDefinitionSyncService({ runtimeRoot });
+  const previous: BotDefinition = {
+    schema: BOT_DEFINITION_SCHEMA,
+    botId: '43',
+    model: {
+      kind: 'custom', protocol: 'openai-responses', apiBase: 'https://models.example.test/v1',
+      model: 'previous-model', apiKey: 'test-model-key', contextWindowTokens: 128000,
+    },
+    prompt: { selected: 'custom', customSystemPrompt: 'Unchanged prompt.' },
+    skills: [TEST_SKILL_REFERENCE],
+  };
+  const desired: BotDefinition = {
+    ...previous,
+    model: { ...previous.model, model: 'next-model' },
+  };
+  definitions.acceptCanonical(previous);
+  const skillsRoot = path.join(runtimeRoot, 'skills');
+  if (workspaceCase === 'corrupt') {
+    const corruptRoot = path.join(skillsRoot, 'server-local');
+    fs.mkdirSync(corruptRoot, { recursive: true });
+    fs.writeFileSync(path.join(corruptRoot, 'SKILL.md'), '---\nname: [invalid\n---\n');
+  }
+  new BotSkillWorkspaceService(runtimeRoot).activate('43');
+  new BotSkillBaseStore(runtimeRoot).write({
+    schema: 'xiaoba.bot-skill-sync-base.v2',
+    botId: '43',
+    definitionRevision: 6,
+    skills: [{
+      localSkillId: 'local-server-skill',
+      name: 'server-local',
+      installName: 'server-local',
+      contentHash: 'b'.repeat(64),
+      reference: TEST_SKILL_REFERENCE,
+    }],
+    updatedAt: new Date().toISOString(),
+  });
+
+  let definitionReads = 0;
+  const acks: unknown[] = [];
+  t.mock.method(globalThis, 'fetch', async (input: string | URL | Request, init?: RequestInit) => {
+    const url = new URL(String(input));
+    const method = init?.method || 'GET';
+    if (url.pathname === '/api/bot/definition' && method === 'GET') {
+      definitionReads += 1;
+      if (definitionReads === 3) {
+        return Response.json({ error: 'temporary outage' }, { status: 503 });
+      }
+      return Response.json({ configured: true, revision: 7, definition: desired });
+    }
+    if (url.pathname === '/api/bot/definition/ack' && method === 'POST') {
+      acks.push(JSON.parse(String(init?.body)));
+      return Response.json({ status: 'applied' });
+    }
+    if (url.pathname === '/api/bot/definition/default-prompt') {
+      return Response.json({ status: 'stored' });
+    }
+    throw new Error(`Unexpected test request: ${method} ${url.pathname}`);
+  });
+  let stopped = 0;
+  const oldBot = {
+    isIdleForRuntimeReload: () => true,
+    destroy: async () => { stopped += 1; },
+  } as CatsCompanyBot;
+
+  const result = await applyCloudModelRuntimeSelection({
+    runtimeRoot,
+    botId: '43',
+    auth,
+    selection: {
+      kind: 'custom', modelId: 'next-model', customModel: desired.model,
+      revision: 7, definition: desired,
+    },
+    canApply: () => true,
+    connectorConfig: {
+      serverUrl: 'wss://cats.example.test/v0/channels', apiKey: 'test-bot-key', botUid: '43',
+    },
+    currentBot: () => oldBot,
+    replaceBot: () => assert.fail('an unverified workspace must not replace the connector'),
+    scheduleAckRetry: () => assert.fail('an unverified workspace must not schedule an ACK'),
+    clearAckRetry: () => {},
+  });
+
+  assert.equal(result, 'deferred');
+  assert.equal(definitionReads, 3, 'strict Skill activation must re-read the cloud definition');
+  assert.deepEqual(acks, []);
+  assert.equal(stopped, 0);
+  assert.deepEqual(definitions.read('43')?.model, previous.model);
+});
+}
 
 for (const failure of [502, 503, 504, 429, 'timeout', 'reset', 'shutdown'] as const) {
 for (const failureRead of [3, 4]) {
@@ -408,4 +523,34 @@ test(`cloud recheck ${failure} at read ${failureRead} preserves the old connecto
 });
 
 }
+}
+
+const TEST_SKILL_REFERENCE: BotSkillRef = {
+  source: 'skillhub',
+  skillId: 'private/server-local',
+  version: 'sha256-server-local',
+  contentHash: 'a'.repeat(64),
+};
+
+function writeVerifiedSkillBase(
+  runtimeRoot: string,
+  botId: string,
+  definitionRevision: number,
+  reference: BotSkillRef,
+): void {
+  const local = scanBotSkillWorkspace(path.join(runtimeRoot, 'skills'), { writeMarkers: false });
+  assert.equal(local.length, 1);
+  new BotSkillBaseStore(runtimeRoot).write({
+    schema: 'xiaoba.bot-skill-sync-base.v2',
+    botId,
+    definitionRevision,
+    skills: local.map(entry => ({
+      localSkillId: entry.localSkillId,
+      name: entry.name,
+      installName: entry.installName,
+      contentHash: entry.contentHash,
+      reference,
+    })),
+    updatedAt: new Date().toISOString(),
+  });
 }

--- a/tests/cloud-bot-model-apply-retry.test.ts
+++ b/tests/cloud-bot-model-apply-retry.test.ts
@@ -311,6 +311,107 @@ test('post-start prompt-only updates reuse unchanged Skills without restarting t
   assert.deepEqual(definitions.read('43')?.prompt, desired.prompt);
 });
 
+test('preparation that advances from a prompt-only revision to a model revision restarts before ACK', async t => {
+  const runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'model-apply-advanced-revision-'));
+  t.after(() => fs.rmSync(runtimeRoot, { recursive: true, force: true }));
+  const configService = createCatsCoLocalConfigService({ runtimeRoot });
+  configService.save({
+    version: 1,
+    endpoints: { httpBaseUrl: 'https://cats.example.test', serverUrl: 'wss://cats.example.test/v0/channels' },
+    account: { token: 'test-owner-token', uid: '7' },
+    currentBot: { uid: '43', apiKey: 'test-bot-key', boundByUserUid: '7', bindingSource: 'test' },
+  });
+  const auth = configService.getAuthState();
+  const definitions = createBotDefinitionSyncService({ runtimeRoot });
+  const previous: BotDefinition = {
+    schema: BOT_DEFINITION_SCHEMA,
+    botId: '43',
+    model: {
+      kind: 'custom', protocol: 'openai-responses', apiBase: 'https://models.example.test/v1',
+      model: 'old-model', apiKey: 'test-model-key', contextWindowTokens: 128000,
+    },
+    prompt: { selected: 'custom', customSystemPrompt: 'Previous prompt.' },
+    skills: [TEST_SKILL_REFERENCE],
+  };
+  const queuedPromptOnly: BotDefinition = {
+    ...previous,
+    prompt: { selected: 'custom', customSystemPrompt: 'Queued prompt.' },
+  };
+  const advancedModelChange: BotDefinition = {
+    ...queuedPromptOnly,
+    model: { ...previous.model, model: 'new-model' },
+  };
+  definitions.acceptCanonical(previous);
+  const localSkillRoot = path.join(runtimeRoot, 'skills', 'server-local');
+  fs.mkdirSync(localSkillRoot, { recursive: true });
+  fs.writeFileSync(path.join(localSkillRoot, 'SKILL.md'), 'verified local content\n');
+  writeVerifiedSkillBase(runtimeRoot, '43', 6, TEST_SKILL_REFERENCE);
+
+  let definitionReads = 0;
+  const acks: unknown[] = [];
+  t.mock.method(globalThis, 'fetch', async (input: string | URL | Request, init?: RequestInit) => {
+    const url = new URL(String(input));
+    const method = init?.method || 'GET';
+    if (url.pathname === '/api/bot/definition' && method === 'GET') {
+      definitionReads += 1;
+      return Response.json({
+        configured: true,
+        revision: definitionReads === 1 ? 7 : 8,
+        definition: definitionReads === 1 ? queuedPromptOnly : advancedModelChange,
+      });
+    }
+    if (url.pathname === '/api/bot/definition/ack' && method === 'POST') {
+      acks.push(JSON.parse(String(init?.body)));
+      return Response.json({ status: 'applied' });
+    }
+    if (url.pathname === '/api/bot/definition/default-prompt') {
+      return Response.json({ status: 'stored' });
+    }
+    throw new Error(`Unexpected test request: ${method} ${url.pathname}`);
+  });
+
+  let idleChecks = 0;
+  let stopped = 0;
+  let started = 0;
+  const oldBot = {
+    isIdleForRuntimeReload: () => { idleChecks += 1; return true; },
+    destroy: async () => { stopped += 1; },
+  } as CatsCompanyBot;
+  let bot = oldBot;
+  t.mock.method(CatsCompanyBot.prototype, 'start', async function (this: CatsCompanyBot) {
+    started += 1;
+    t.after(() => this.destroy());
+  });
+  t.mock.method(CatsCompanyBot.prototype, 'waitUntilReady', async () => {});
+
+  const result = await applyCloudModelRuntimeSelection({
+    runtimeRoot,
+    botId: '43',
+    auth,
+    selection: {
+      kind: 'custom', modelId: 'old-model', customModel: queuedPromptOnly.model,
+      revision: 7, definition: queuedPromptOnly,
+    },
+    canApply: () => true,
+    connectorConfig: {
+      serverUrl: 'wss://cats.example.test/v0/channels', apiKey: 'test-bot-key', botUid: '43',
+    },
+    currentBot: () => bot,
+    replaceBot: next => { bot = next; },
+    scheduleAckRetry: () => assert.fail('ACK should succeed'),
+    clearAckRetry: () => {},
+  });
+
+  assert.equal(result, 'applied');
+  assert.equal(definitionReads, 2);
+  assert.equal(idleChecks, 1, 'the effective model change must re-check connector idleness');
+  assert.equal(stopped, 1);
+  assert.equal(started, 1);
+  assert.notEqual(bot, oldBot);
+  assert.deepEqual(acks, [{ revision: 8 }]);
+  assert.deepEqual(definitions.read('43')?.model, advancedModelChange.model);
+});
+
 for (const workspaceCase of ['missing', 'corrupt'] as const) {
 test(`unchanged Skill refs do not bypass strict activation for a ${workspaceCase} workspace`, async t => {
   const runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), `model-apply-${workspaceCase}-skills-`));


### PR DESCRIPTION
## Summary

- compare canonical Skill references before applying a unified BotDefinition revision
- for model/prompt-only updates, enter the normal locked workspace activation path and recover the target Bot workspace before considering reuse
- reuse unchanged Skills without package downloads only after verifying active Bot ownership, Base metadata, and local package hashes
- fall back to the existing strict Cloud activation path whenever the workspace is missing, corrupt, mismatched, or cannot be verified
- compute the connector restart requirement again from the final Definition returned by preparation, so a newer model-changing revision cannot be acknowledged without replacing the connector
- apply the same isolation during startup/restart and live cloud updates
- keep `XIAOBA_PRESERVE_SKILLS=1` as the explicit highest-priority operator override
- restore the exact previous Skill references when preparation fails, while retaining successfully prepared Skills if a later connector restart is deferred or rolled back

## Safety boundary

- reference equality alone is never treated as proof that the target Bot workspace is active or healthy
- B -> A -> B switching restores and verifies B before its unified revision can be acknowledged
- an actual `skills` reference change still enters the existing strict Skill reconciliation path
- missing or corrupt local state cannot be acknowledged as applied; strict activation must succeed first
- if preparation advances beyond a preflighted prompt-only revision to a model-changing revision, connector idleness is re-checked and the final revision is restarted before ACK
- transient cloud failures still leave the old connector and old definition active for retry

## Verification

- `npm run build`
- 139 focused BotDefinition / Skill synchronization tests passed, including B -> A -> B recovery, missing/corrupt workspace, and r7 prompt-only -> r8 model-change race regressions
- `git diff --check`
- full local runtime suite before the review follow-ups: 1848 passed; one flaky dashboard test passed on isolated rerun, while two unrelated environment/baseline tests remained (`jq` missing for the worker updater test and the bundled knowledge test's existing file-level failure)
