### PR TITLE
fix: support native DeepSeek Flash Responses and scoped reasoning replay

### DIFF
--- a/src/core/conversation-runner.ts
+++ b/src/core/conversation-runner.ts
@@ -585,6 +585,9 @@ export class ConversationRunner {
           const finalAssistantMessage: Message = {
             role: 'assistant',
             content: visibleContent,
+            // Private provider replay stays separate from user-visible content.
+            providerContent: response.providerContent,
+            providerState: response.providerState,
             ...(this.episodeId ? { __episodeId: this.episodeId } : {}),
           };
           messages.push(finalAssistantMessage);

--- a/src/providers/deepseek/catalog-profile.ts
+++ b/src/providers/deepseek/catalog-profile.ts
@@ -20,3 +20,11 @@ export const DEEPSEEK_RELAY_MODEL_PROFILE: RelayModelProfile = {
     streaming: true,
   },
 };
+
+export const DEEPSEEK_FLASH_RELAY_MODEL_PROFILE: RelayModelProfile = {
+  ...DEEPSEEK_RELAY_MODEL_PROFILE,
+  id: 'deepseek-flash',
+  model: 'deepseek-flash',
+  label: 'DeepSeek Flash',
+  modelsDevModel: 'deepseek-flash',
+};

--- a/src/providers/deepseek/responses-policy.ts
+++ b/src/providers/deepseek/responses-policy.ts
@@ -13,12 +13,17 @@ export const DEEPSEEK_RESPONSES_PROFILE = Object.freeze({
   reasoningEfforts: ['none', 'low', 'high', 'max'] as const,
 });
 
+// Protocol recognition only: these remain distinct model/catalog identities.
+export const DEEPSEEK_FLASH_MODEL_IDS = new Set([
+  'deepseek-flash', 'deepseek-v4-flash', 'deepseek-v4-flash-vision-exp',
+]);
+
 export function isDeepSeekResponses(
   apiMode: ChatConfig['openaiApiMode'],
   model: unknown,
 ): boolean {
   return apiMode === DEEPSEEK_RESPONSES_PROFILE.apiMode
-    && String(model || '').trim().toLowerCase() === DEEPSEEK_RESPONSES_PROFILE.publicModelId;
+    && DEEPSEEK_FLASH_MODEL_IDS.has(String(model || '').trim().toLowerCase());
 }
 
 export function normalizeDeepSeekReasoningEffort(
@@ -48,7 +53,10 @@ export function applyDeepSeekResponsesRequestPolicy(
   if (normalizedEffort) body.reasoning = { effort: normalizedEffort };
   else delete body.reasoning;
 
-  if (Array.isArray(body.tools)) {
+  // Native thinking mode still rejects required/named tool_choice in live API.
+  const nativeNonThinking = String(body.model || '').toLowerCase() === 'deepseek-flash'
+    && normalizedEffort === 'none';
+  if (!nativeNonThinking && Array.isArray(body.tools)) {
     const toolChoice = body.tool_choice;
     if (toolChoice !== undefined && !['auto', 'none'].includes(toolChoice)) {
       body.tool_choice = 'auto';

--- a/src/providers/openai-provider.ts
+++ b/src/providers/openai-provider.ts
@@ -678,6 +678,14 @@ export class OpenAIProvider implements AIProvider {
         }
         continue;
       }
+      if (message.role === 'assistant' && this.usesDeepSeekResponsesPolicy()
+        && this.canReplayProviderContent(message, 'openai-responses')) {
+        // A tool-enabled conversation also needs reasoning from ordinary answers.
+        input.push(...(message.providerContent || [])
+          .filter(item => item.type === 'reasoning')
+          .map(item => this.responsesReplayItem(item))
+          .filter(Boolean));
+      }
       input.push({
         role: transientProjection ? 'developer' : message.role,
         content: this.responsesMessageContent(message.content),
@@ -1243,7 +1251,7 @@ export class OpenAIProvider implements AIProvider {
     const stopReason = response?.status === 'incomplete'
       ? incompleteReason === 'max_output_tokens' ? 'length' : incompleteReason || 'incomplete'
       : toolCalls.length > 0 ? 'tool_calls' : response?.status || undefined;
-    const providerContent = toolCalls.length > 0
+    const providerContent = toolCalls.length > 0 || this.usesDeepSeekResponsesPolicy()
       ? output
         .filter((item: any) => this.isResponsesReplayItem(item))
         .map((item: any) => this.responsesReplayItem(item))

--- a/src/utils/model-capabilities.ts
+++ b/src/utils/model-capabilities.ts
@@ -4,7 +4,7 @@ import { probeVisionCapability, type VisionCapabilityState, type VisionProbeOpti
 import { isCatsRelayApiBase } from './catsco-domains';
 
 const KNOWN_TEXT_ONLY_MODEL_PATTERNS = [
-  /^deepseek-(?:chat|reasoner|v4-flash)$/i,
+  /^deepseek-(?:chat|reasoner)$/i,
   /gpt-3\.5/i,
   /text-/i,
   /embedding/i,
@@ -13,6 +13,7 @@ const KNOWN_TEXT_ONLY_MODEL_PATTERNS = [
 ];
 
 const KNOWN_VISION_MODEL_PATTERNS = [
+  /^deepseek-(?:flash|v4-flash(?:-vision-exp)?)$/i,
   /claude/i,
   /gpt-4o/i,
   /gpt-4\.1/i,
@@ -49,7 +50,7 @@ export function isPrimaryModelVisionCapable(config: Pick<ChatConfig, 'apiUrl' | 
 
   // Anthropic-compatible endpoints from text-only providers often reject image blocks.
   if (apiUrl.includes('deepseek.com') || apiUrl.includes('minimaxi.com')) {
-    return includesAny(modelKey, [/minimax-m3/i, /vision/i, /vl/i, /image/i, /multimodal/i, /omni/i]);
+    return includesAny(modelKey, [/^deepseek-(?:flash|v4-flash(?:-vision-exp)?)$/i, /minimax-m3/i, /vision/i, /vl/i, /image/i, /multimodal/i, /omni/i]);
   }
 
   if (includesAny(modelKey, KNOWN_TEXT_ONLY_MODEL_PATTERNS)) {
@@ -90,7 +91,7 @@ export async function resolvePrimaryModelVisionCapability(
   }
 
   if (apiUrl.includes('deepseek.com') || apiUrl.includes('minimaxi.com')) {
-    if (includesAny(modelKey, [/minimax-m3/i, /vision/i, /vl/i, /image/i, /multimodal/i, /omni/i])) {
+    if (includesAny(modelKey, [/^deepseek-(?:flash|v4-flash(?:-vision-exp)?)$/i, /minimax-m3/i, /vision/i, /vl/i, /image/i, /multimodal/i, /omni/i])) {
       return 'supported';
     }
     if (includesAny(modelKey, KNOWN_TEXT_ONLY_MODEL_PATTERNS)) return 'unsupported';

--- a/src/utils/relay-model-profiles.ts
+++ b/src/utils/relay-model-profiles.ts
@@ -1,4 +1,4 @@
-import { DEEPSEEK_RELAY_MODEL_PROFILE } from '../providers/deepseek/catalog-profile';
+import { DEEPSEEK_RELAY_MODEL_PROFILE, DEEPSEEK_FLASH_RELAY_MODEL_PROFILE } from '../providers/deepseek/catalog-profile';
 
 export type RelayModelFamily = 'catalog' | 'minimax' | 'deepseek' | 'glm' | 'gpt';
 export type RelayModelProvider = 'anthropic' | 'openai';
@@ -136,6 +136,7 @@ export const RELAY_MODEL_PROFILES: RelayModelProfile[] = [
     },
   },
   DEEPSEEK_RELAY_MODEL_PROFILE,
+  DEEPSEEK_FLASH_RELAY_MODEL_PROFILE,
   {
     id: 'glm-5.3-flash',
     label: 'GLM 5.3 Flash',

--- a/tests/deepseek-flash-replay.test.ts
+++ b/tests/deepseek-flash-replay.test.ts
@@ -1,0 +1,73 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { OpenAIProvider } from '../src/providers/openai-provider';
+import { isDeepSeekResponses, applyDeepSeekResponsesRequestPolicy } from '../src/providers/deepseek/responses-policy';
+import { isPrimaryModelVisionCapable } from '../src/utils/model-capabilities';
+import { relayModelIdsMatch } from '../src/utils/relay-model-profiles';
+
+const config = { apiUrl: 'https://api.deepseek.com', apiKey: 'test', model: 'deepseek-flash', openaiApiMode: 'responses' as const };
+
+test('native Flash is a separate selection with Responses and image support', () => {
+  assert.equal(isDeepSeekResponses('responses', 'deepseek-flash'), true);
+  assert.equal(relayModelIdsMatch('deepseek-flash', 'deepseek-v4-flash'), false);
+  assert.equal(isPrimaryModelVisionCapable(config), true);
+});
+
+test('ordinary answers preserve scoped plaintext reasoning across the next turn', () => {
+  const provider = new OpenAIProvider(config) as any;
+  const result = provider.parseResponsesResponse({
+    status: 'completed', output: [
+      { type: 'reasoning', content: [{ type: 'reasoning_text', text: 'test replay marker' }] },
+      { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'answer' }] },
+    ],
+  });
+  assert.equal(result.content, 'answer');
+  const messages = [{ role: 'assistant', content: result.content, providerContent: result.providerContent, providerState: result.providerState }, { role: 'user', content: 'next' }];
+  const wire = provider.buildResponsesRequestBody(messages);
+  assert.deepEqual(wire.input.map((item: any) => item.type || item.role), ['reasoning', 'assistant', 'user']);
+  assert.equal(wire.input[0].content[0].text, 'test replay marker');
+  const other = new OpenAIProvider({ ...config, model: 'gpt-5.6-terra' }) as any;
+  assert.equal(JSON.stringify(other.buildResponsesRequestBody(messages)).includes('test replay marker'), false);
+});
+
+test('native Flash strips unsupported encrypted state from tool replay', () => {
+  const provider = new OpenAIProvider(config) as any;
+  const result = provider.parseResponsesResponse({ output: [
+    { type: 'reasoning', content: [{ type: 'reasoning_text', text: 'tool replay' }], encrypted_content: 'not-supported' },
+    { type: 'function_call', call_id: 'call1', name: 'lookup', arguments: '{}' },
+  ] });
+  const wire = provider.buildResponsesRequestBody([
+    { role: 'assistant', content: null, tool_calls: result.toolCalls, providerContent: result.providerContent, providerState: result.providerState },
+    { role: 'tool', tool_call_id: 'call1', content: 'result' },
+  ]);
+  assert.deepEqual(wire.input.map((item: any) => item.type), ['reasoning', 'function_call', 'function_call_output']);
+  assert.equal(JSON.stringify(wire).includes('not-supported'), false);
+});
+
+test('forced tool choice is retained only when native thinking is disabled', () => {
+  const body: any = { model: 'deepseek-flash', tools: [{ type: 'function', name: 'lookup' }], tool_choice: 'required' };
+  applyDeepSeekResponsesRequestPolicy(body, 'low');
+  assert.equal(body.tool_choice, 'auto');
+  body.tool_choice = 'required';
+  applyDeepSeekResponsesRequestPolicy(body, 'disabled');
+  assert.equal(body.tool_choice, 'required');
+  assert.deepEqual(body.reasoning, { effort: 'none' });
+});
+
+test('GPT history keeps completed tool evidence without replaying encrypted reasoning', () => {
+  const gpt = new OpenAIProvider({ ...config, model: 'gpt-5.6-terra' }) as any;
+  const reply = gpt.parseResponsesResponse({ output: [
+    { type: 'reasoning', encrypted_content: 'foreign-encrypted-test-state', summary: [] },
+    { type: 'function_call', call_id: 'old_call', name: 'lookup', arguments: '{}' },
+  ] });
+  const native = new OpenAIProvider(config) as any;
+  const wire = native.buildResponsesRequestBody([
+    { role: 'assistant', content: null, tool_calls: reply.toolCalls, providerContent: reply.providerContent, providerState: reply.providerState },
+    { role: 'tool', tool_call_id: 'old_call', content: 'completed record 5729' },
+    { role: 'user', content: 'Continue from the record.' },
+  ]);
+  assert.equal(JSON.stringify(wire).includes('foreign-encrypted-test-state'), false);
+  assert.equal(wire.input[0].type, 'function_call');
+  assert.equal(wire.input[1].call_id, 'old_call');
+  assert.equal(wire.input[1].output, 'completed record 5729');
+});

--- a/tests/model-capabilities.test.ts
+++ b/tests/model-capabilities.test.ts
@@ -12,14 +12,14 @@ describe('model capabilities', () => {
     assert.strictEqual(isPrimaryModelVisionCapable({ provider: 'openai', model: 'gpt-4o' }), true);
   });
 
-  test('treats DeepSeek and MiniMax text models as non-vision even through compatible endpoints', () => {
+  test('recognizes native DeepSeek vision and keeps MiniMax M2 text-only', () => {
     assert.strictEqual(
       isPrimaryModelVisionCapable({
         provider: 'anthropic',
         apiUrl: 'https://api.deepseek.com/anthropic',
         model: 'deepseek-v4-flash',
       }),
-      false,
+      true,
     );
     assert.strictEqual(
       isPrimaryModelVisionCapable({
@@ -62,6 +62,7 @@ describe('model capabilities', () => {
         { model: 'MiniMax-M2.7', provider: 'anthropic', vision: false, context: 204_800 },
         { model: 'MiniMax-M3', provider: 'anthropic', vision: true, context: 1_000_000 },
         { model: 'deepseek-v4-flash', provider: 'openai', vision: true, context: 1_000_000 },
+        { model: 'deepseek-flash', provider: 'openai', vision: true, context: 1_000_000 },
         { model: 'glm-5.3-flash', provider: 'anthropic', vision: true, context: 1_000_000 },
         { model: 'gpt-5.6-terra', provider: 'openai', vision: true, context: 256_000 },
         { model: 'gpt-5.6-sol', provider: 'openai', vision: true, context: 256_000 },


### PR DESCRIPTION
新增独立 `deepseek-flash` 模型档案，使用 Responses 与原生图片能力。修复 DeepSeek 普通回答的明文 reasoning 未保留到下一轮的问题，使工具历史、后续回答按 provider/model/endpoint 范围回放，切换模型时丢弃不兼容的专属状态并保留通用工具结果。

新旧模型保持独立，客户端不自动迁移选择。thinking 模式的强制 tool_choice 按真实上游约束改为 auto，关闭思考时保留。没有改生产压缩阈值，也不持久化 provider 私有状态。

验证：117 项协议、压缩、工具历史和模型能力测试通过，TypeScript 检查通过。真实 Responses 流式/非流式工具追问通过；真实 GLM 5.3 Flash、MiniMax M3 工具历史切换通过。真实 checkpoint 连续压缩三次后，四项细节回忆及工具继续调用均通过，保存/加载后再验证通过。测试将触发线降低至 24k、每次压缩前约 61–67k，未做 1M 极限测试。

GPT 专属加密状态的跨模型隔离回归通过；真实 GPT 来源受 Sol 权限 403 和 Terra 503 阻塞，尚未完成。新公开 Relay 与网页入口待配套发布后验收。

配套 Relay：https://github.com/buildsense-ai/cats-bifrost-deploy/pull/108

追加真实验收：旧 deepseek-v4-flash Responses 与 MiniMax M2.7 的工具历史切换也均通过，四项细节保留。GPT Terra 再试仍未能在 90 秒内生成来源历史，真实 GPT 切换继续标为未完成。
