### PR TITLE
Scope connector grants to trusted SkillHub packages

### DIFF
--- a/src/bot-skills/trusted-script-execution.ts
+++ b/src/bot-skills/trusted-script-execution.ts
@@ -24,6 +24,43 @@ export type TrustedBotSkillScriptDecision =
   | { ok: true; invocation: TrustedBotSkillScriptInvocation }
   | { ok: false; reason: string };
 
+const CONNECTOR_ENV_NAMES = [
+  'CATSCO_SHIMO_CONNECTOR_URL',
+  'CATSCO_ACTOR_TOKEN',
+  'CATSCO_SKILL_ID',
+] as const;
+
+/**
+ * Removes connector capabilities from the shared Runtime environment and
+ * injects one only when the verified SkillHub package id matches the grant.
+ */
+export function withTrustedBotSkillConnectorEnvironment(
+  invocation: TrustedBotSkillScriptInvocation | undefined,
+  context: ToolExecutionContext,
+  environment: NodeJS.ProcessEnv,
+  now = Date.now(),
+): NodeJS.ProcessEnv {
+  const isolated = { ...environment };
+  for (const name of CONNECTOR_ENV_NAMES) delete isolated[name];
+  if (!invocation) return isolated;
+
+  const grant = [...(context.skillConnectorGrants || [])]
+    .filter(candidate => (
+      candidate.provider === 'shimo'
+      && candidate.skillId === invocation.skillId
+      && candidate.expiresAt > now
+      && safeConnectorURL(candidate.connectorUrl)
+      && Boolean(candidate.actorToken)
+    ))
+    .sort((left, right) => right.expiresAt - left.expiresAt)[0];
+  if (!grant) return isolated;
+
+  isolated.CATSCO_SHIMO_CONNECTOR_URL = grant.connectorUrl;
+  isolated.CATSCO_ACTOR_TOKEN = grant.actorToken;
+  isolated.CATSCO_SKILL_ID = grant.skillId;
+  return isolated;
+}
+
 /**
  * Resolve the deliberately narrow compatibility path for script-backed formal
  * Bot Skills. The model still calls execute_shell, but accepted commands never
@@ -261,6 +298,18 @@ function sameIdentity(left: unknown, right: unknown): boolean {
 
 function stringValue(value: unknown): string {
   return typeof value === 'string' ? value.trim() : '';
+}
+
+function safeConnectorURL(value: string): boolean {
+  try {
+    const parsed = new URL(value);
+    if (parsed.username || parsed.password || parsed.search || parsed.hash) return false;
+    const hostname = parsed.hostname.toLowerCase();
+    return parsed.protocol === 'https:'
+      || (parsed.protocol === 'http:' && ['127.0.0.1', 'localhost', '::1'].includes(hostname));
+  } catch {
+    return false;
+  }
 }
 
 function denied(reason: string): TrustedBotSkillScriptDecision {

--- a/src/bot-skills/trusted-script-execution.ts
+++ b/src/bot-skills/trusted-script-execution.ts
@@ -44,6 +44,9 @@ export function withTrustedBotSkillConnectorEnvironment(
   for (const name of CONNECTOR_ENV_NAMES) delete isolated[name];
   if (!invocation) return isolated;
 
+  // TODO(connectors): only the `shimo` provider has a value mapping today. When
+  // a second provider lands, map its grant to that provider's own env names
+  // instead of silently ignoring the grant.
   const grant = [...(context.skillConnectorGrants || [])]
     .filter(candidate => (
       candidate.provider === 'shimo'

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -16,7 +16,7 @@ import { createCatsCoAttachmentGrant, createCatsCoLocalDeviceGrant } from './loc
 import { extractCatsCoDeviceGrants } from './device-grants';
 import { extractCatsCoDeviceSelection } from './device-selection';
 import { extractCatsCoRuntimeContext } from './runtime-context';
-import { extractCatsCoSkillConnectorGrants } from './skill-connector-grants';
+import { extractCatsCoSkillConnectorGrants, mergeSkillConnectorGrants } from './skill-connector-grants';
 import { MessageSessionManager } from '../core/message-session-manager';
 import {
   AgentServices,
@@ -3281,7 +3281,11 @@ export class CatsCompanyBot {
     const deviceGrants = messages.flatMap(item => item.deviceGrants || []);
     const deviceSelection = [...messages].reverse().find(item => item.deviceSelection)?.deviceSelection;
     const targetRoutes = [...messages].reverse().find(item => item.targetRoutes)?.targetRoutes;
-    const skillConnectorGrants = [...messages].reverse().find(item => item.skillConnectorGrants?.length)?.skillConnectorGrants;
+    // Union the whole batch so two grants arriving together both survive; a
+    // later grant for the same provider + Skill still supersedes an earlier one.
+    const skillConnectorGrants = mergeSkillConnectorGrants(
+      messages.flatMap(item => item.skillConnectorGrants || []),
+    );
     const artifactContextMessage = [...messages]
       .reverse()
       .find(item => Object.prototype.hasOwnProperty.call(item, 'artifactContextRef'));
@@ -3293,7 +3297,7 @@ export class CatsCompanyBot {
       deviceSelection,
       targetRoutes,
       artifactContextRef: artifactContextMessage?.artifactContextRef,
-      skillConnectorGrants,
+      skillConnectorGrants: skillConnectorGrants.length > 0 ? skillConnectorGrants : undefined,
     };
   }
 

--- a/src/catscompany/index.ts
+++ b/src/catscompany/index.ts
@@ -16,6 +16,7 @@ import { createCatsCoAttachmentGrant, createCatsCoLocalDeviceGrant } from './loc
 import { extractCatsCoDeviceGrants } from './device-grants';
 import { extractCatsCoDeviceSelection } from './device-selection';
 import { extractCatsCoRuntimeContext } from './runtime-context';
+import { extractCatsCoSkillConnectorGrants } from './skill-connector-grants';
 import { MessageSessionManager } from '../core/message-session-manager';
 import {
   AgentServices,
@@ -32,7 +33,7 @@ import { ChannelCallbacks, DeviceRpcTransport, TargetRoutes, ThinToolRpcTranspor
 import { ContentBlock } from '../types';
 import type { PendingUserInput } from '../core/conversation-runner';
 import type { StreamRetryInfo } from '../providers/provider';
-import type { DeviceGrantOperation, ExecutionScope, ScopedDeviceGrant, ScopedDeviceSelection, ScopedLocalDeviceGrant, ScopedLocalFileGrant } from '../types/session-identity';
+import type { DeviceGrantOperation, ExecutionScope, ScopedDeviceGrant, ScopedDeviceSelection, ScopedLocalDeviceGrant, ScopedLocalFileGrant, SkillConnectorGrant } from '../types/session-identity';
 import { AdapterRuntimeBundle, createAdapterRuntime } from '../runtime/adapter-runtime';
 import { randomUUID } from 'crypto';
 import { hostname, platform } from 'os';
@@ -106,6 +107,7 @@ interface QueuedMessage {
   executionScope: ParsedCatsMessage['executionScope'];
   artifactContextRef?: string;
   artifactTaskRef?: string;
+  skillConnectorGrants?: SkillConnectorGrant[];
   deviceGrants?: ScopedDeviceGrant[];
   deviceSelection?: ScopedDeviceSelection;
   targetRoutes?: TargetRoutes;
@@ -1691,6 +1693,7 @@ export class CatsCompanyBot {
         executionScope: msg.executionScope,
         artifactContextRef: msg.artifactContextRef,
         artifactTaskRef: msg.artifactTaskRef,
+        skillConnectorGrants: msg.skillConnectorGrants,
         deviceGrants: msg.deviceGrants,
         deviceSelection: msg.deviceSelection,
         targetRoutes: msg.targetRoutes,
@@ -1741,6 +1744,7 @@ export class CatsCompanyBot {
           executionScope: msg.executionScope,
           artifactContextRef: msg.artifactContextRef,
           artifactTaskRef: msg.artifactTaskRef,
+          skillConnectorGrants: msg.skillConnectorGrants,
           localDeviceGrant: this.localDeviceGrant,
           deviceGrants: msg.deviceGrants,
           deviceSelection: msg.deviceSelection,
@@ -2250,6 +2254,7 @@ export class CatsCompanyBot {
       executionScope,
       artifactContextRef: envelope.artifactContextRef,
       artifactTaskRef: envelope.artifactTaskRef,
+      skillConnectorGrants: extractCatsCoSkillConnectorGrants(ctx.metadata, executionScope),
       deviceGrants: extractCatsCoDeviceGrants(ctx.metadata, executionScope),
       deviceSelection: extractCatsCoDeviceSelection(ctx.metadata, executionScope),
       targetRoutes,
@@ -3109,6 +3114,7 @@ export class CatsCompanyBot {
             executionScope: msg.executionScope,
             artifactContextRef: msg.artifactContextRef,
             artifactTaskRef: msg.artifactTaskRef,
+            skillConnectorGrants: msg.skillConnectorGrants,
             localDeviceGrant: this.localDeviceGrant,
             deviceGrants: msg.deviceGrants,
             deviceSelection: msg.deviceSelection,
@@ -3275,10 +3281,11 @@ export class CatsCompanyBot {
     const deviceGrants = messages.flatMap(item => item.deviceGrants || []);
     const deviceSelection = [...messages].reverse().find(item => item.deviceSelection)?.deviceSelection;
     const targetRoutes = [...messages].reverse().find(item => item.targetRoutes)?.targetRoutes;
+    const skillConnectorGrants = [...messages].reverse().find(item => item.skillConnectorGrants?.length)?.skillConnectorGrants;
     const artifactContextMessage = [...messages]
       .reverse()
       .find(item => Object.prototype.hasOwnProperty.call(item, 'artifactContextRef'));
-    if (localFileGrants.length === 0 && deviceGrants.length === 0 && !deviceSelection && !targetRoutes && !artifactContextMessage) return content;
+    if (localFileGrants.length === 0 && deviceGrants.length === 0 && !deviceSelection && !targetRoutes && !artifactContextMessage && !skillConnectorGrants?.length) return content;
     return {
       content,
       localFileGrants: localFileGrants.length > 0 ? localFileGrants : undefined,
@@ -3286,6 +3293,7 @@ export class CatsCompanyBot {
       deviceSelection,
       targetRoutes,
       artifactContextRef: artifactContextMessage?.artifactContextRef,
+      skillConnectorGrants,
     };
   }
 

--- a/src/catscompany/skill-connector-grants.ts
+++ b/src/catscompany/skill-connector-grants.ts
@@ -1,0 +1,71 @@
+import type { ExecutionScope, SkillConnectorGrant } from '../types/session-identity';
+
+const MAX_GRANTS = 4;
+const MAX_TOKEN_LENGTH = 16 * 1024;
+const MAX_FUTURE_MS = 11 * 60 * 1000;
+
+export function extractCatsCoSkillConnectorGrants(
+  metadata: unknown,
+  scope: ExecutionScope,
+  now = Date.now(),
+): SkillConnectorGrant[] {
+  if (
+    scope.source !== 'catscompany'
+    || !scope.isTrusted
+    || scope.identityTrust !== 'server_canonical'
+    || !scope.agentId
+    || !isRecord(metadata)
+  ) return [];
+
+  const container = asRecord(metadata.catsco_skill_connectors);
+  if (container?.schema !== 'catsco.skill_connectors.v1' || !Array.isArray(container.grants)) return [];
+
+  const grants: SkillConnectorGrant[] = [];
+  for (const raw of container.grants.slice(0, MAX_GRANTS)) {
+    const grant = asRecord(raw);
+    const provider = stringValue(grant?.provider).toLowerCase();
+    const skillId = stringValue(grant?.skill_id);
+    const connectorUrl = normalizeConnectorUrl(grant?.connector_url);
+    const actorToken = stringValue(grant?.actor_token);
+    const expiresAt = Date.parse(stringValue(grant?.expires_at));
+    if (
+      !/^[a-z0-9._-]{1,64}$/.test(provider)
+      || !/^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/.test(skillId)
+      || !connectorUrl
+      || !actorToken
+      || actorToken.length > MAX_TOKEN_LENGTH
+      || !Number.isFinite(expiresAt)
+      || expiresAt <= now
+      || expiresAt > now + MAX_FUTURE_MS
+    ) continue;
+    grants.push({ provider, skillId, connectorUrl, actorToken, expiresAt });
+  }
+  return grants;
+}
+
+function normalizeConnectorUrl(value: unknown): string | undefined {
+  try {
+    const parsed = new URL(stringValue(value));
+    if (parsed.username || parsed.password || parsed.search || parsed.hash) return undefined;
+    const hostname = parsed.hostname.toLowerCase();
+    const localHTTP = parsed.protocol === 'http:'
+      && ['127.0.0.1', 'localhost', '::1'].includes(hostname);
+    if (parsed.protocol !== 'https:' && !localHTTP) return undefined;
+    parsed.pathname = parsed.pathname.replace(/\/+$/, '');
+    return parsed.toString().replace(/\/+$/, '');
+  } catch {
+    return undefined;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return isRecord(value) ? value : undefined;
+}
+
+function stringValue(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}

--- a/src/catscompany/skill-connector-grants.ts
+++ b/src/catscompany/skill-connector-grants.ts
@@ -1,8 +1,27 @@
 import type { ExecutionScope, SkillConnectorGrant } from '../types/session-identity';
 
 const MAX_GRANTS = 4;
+// Scan more raw entries than we keep so a malformed leading entry cannot push
+// a valid grant past the cap. The bound keeps attacker-supplied metadata cheap.
+const MAX_SCANNED_GRANTS = 32;
 const MAX_TOKEN_LENGTH = 16 * 1024;
+// Must stay above the CatsCo issuer TTL (currently 10 minutes) so a freshly
+// issued grant is never dropped here; update both sides together.
 const MAX_FUTURE_MS = 11 * 60 * 1000;
+
+/**
+ * Deduplicate grants by provider + Skill id. A later grant for the same pair
+ * supersedes an earlier one, while grants for different Skills stay independent.
+ */
+export function mergeSkillConnectorGrants(
+  grants: readonly SkillConnectorGrant[],
+): SkillConnectorGrant[] {
+  const merged = new Map<string, SkillConnectorGrant>();
+  for (const grant of grants) {
+    merged.set(`${grant.provider}\u0000${grant.skillId}`, grant);
+  }
+  return [...merged.values()];
+}
 
 export function extractCatsCoSkillConnectorGrants(
   metadata: unknown,
@@ -21,7 +40,8 @@ export function extractCatsCoSkillConnectorGrants(
   if (container?.schema !== 'catsco.skill_connectors.v1' || !Array.isArray(container.grants)) return [];
 
   const grants: SkillConnectorGrant[] = [];
-  for (const raw of container.grants.slice(0, MAX_GRANTS)) {
+  // Validate every scanned entry before applying the keep-limit, then merge.
+  for (const raw of container.grants.slice(0, MAX_SCANNED_GRANTS)) {
     const grant = asRecord(raw);
     const provider = stringValue(grant?.provider).toLowerCase();
     const skillId = stringValue(grant?.skill_id);
@@ -40,7 +60,7 @@ export function extractCatsCoSkillConnectorGrants(
     ) continue;
     grants.push({ provider, skillId, connectorUrl, actorToken, expiresAt });
   }
-  return grants;
+  return mergeSkillConnectorGrants(grants).slice(0, MAX_GRANTS);
 }
 
 function normalizeConnectorUrl(value: unknown): string | undefined {

--- a/src/catscompany/types.ts
+++ b/src/catscompany/types.ts
@@ -1,4 +1,4 @@
-import type { ExecutionScope, MessageEnvelope, ScopedDeviceGrant, ScopedDeviceSelection } from '../types/session-identity';
+import type { ExecutionScope, MessageEnvelope, ScopedDeviceGrant, ScopedDeviceSelection, SkillConnectorGrant } from '../types/session-identity';
 import type { TargetRoutes } from '../types/tool';
 
 export type CatsCompanyRuntimeRole = 'desktop' | 'server';
@@ -75,6 +75,8 @@ export interface ParsedCatsMessage {
   artifactContextRef?: string;
   /** 仅当前 turn 有效的 opaque Artifact task ref。 */
   artifactTaskRef?: string;
+  /** Short-lived server-issued connector grants; never copied into model text or durable history. */
+  skillConnectorGrants?: SkillConnectorGrant[];
   /** 服务端签发的当前 turn 用户设备授权 */
   deviceGrants?: ScopedDeviceGrant[];
   /** 服务端为当前 turn 选择的用户设备，或要求先选择设备 */

--- a/src/core/agent-session.ts
+++ b/src/core/agent-session.ts
@@ -6,6 +6,7 @@ import type {
   ScopedLocalDeviceGrant,
   ScopedLocalFileGrant,
   SessionRoute,
+  SkillConnectorGrant,
 } from '../types/session-identity';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -143,6 +144,8 @@ export interface HandleMessageOptions {
   artifactContextRef?: string;
   /** 当前 turn 的短期 Artifact task ref；不进入模型消息或持久历史。 */
   artifactTaskRef?: string;
+  /** Current turn connector capabilities; private runtime state only. */
+  skillConnectorGrants?: SkillConnectorGrant[];
   /** 当前本机运行体授权，例如 CatsCo body/device 绑定。 */
   localDeviceGrant?: ScopedLocalDeviceGrant;
   /** 当前 turn 已授权的用户设备资源。 */
@@ -609,6 +612,7 @@ export class AgentSession {
       let executionScope: ExecutionScope | undefined;
       let artifactContextRef: string | undefined;
       let artifactTaskRef: string | undefined;
+      let skillConnectorGrants: SkillConnectorGrant[] | undefined;
       let localDeviceGrant: ScopedLocalDeviceGrant | undefined;
       let deviceGrants: ScopedDeviceGrant[] | undefined;
       let deviceSelection: ScopedDeviceSelection | undefined;
@@ -626,6 +630,7 @@ export class AgentSession {
           || 'executionScope' in callbacksOrOptions
           || 'artifactContextRef' in callbacksOrOptions
           || 'artifactTaskRef' in callbacksOrOptions
+          || 'skillConnectorGrants' in callbacksOrOptions
           || 'localDeviceGrant' in callbacksOrOptions
           || 'deviceGrants' in callbacksOrOptions
           || 'deviceSelection' in callbacksOrOptions
@@ -645,6 +650,7 @@ export class AgentSession {
           executionScope = opts.executionScope;
           artifactContextRef = opts.artifactContextRef;
           artifactTaskRef = opts.artifactTaskRef;
+          skillConnectorGrants = opts.skillConnectorGrants;
           localDeviceGrant = opts.localDeviceGrant;
           deviceGrants = opts.deviceGrants;
           deviceSelection = opts.deviceSelection;
@@ -735,6 +741,7 @@ export class AgentSession {
           executionScope,
           artifactContextRef,
           artifactTaskRef,
+          skillConnectorGrants,
           localDeviceGrant,
           deviceGrants,
           deviceSelection,

--- a/src/core/agent-turn-controller.ts
+++ b/src/core/agent-turn-controller.ts
@@ -7,6 +7,7 @@ import type {
   ScopedLocalDeviceGrant,
   ScopedLocalFileGrant,
   SessionRoute,
+  SkillConnectorGrant,
 } from '../types/session-identity';
 import {
   ChannelCallbacks,
@@ -82,6 +83,7 @@ export interface RunAgentTurnParams {
   executionScope?: ExecutionScope;
   artifactContextRef?: string;
   artifactTaskRef?: string;
+  skillConnectorGrants?: SkillConnectorGrant[];
   localDeviceGrant?: ScopedLocalDeviceGrant;
   deviceGrants?: ScopedDeviceGrant[];
   deviceSelection?: ScopedDeviceSelection;
@@ -190,6 +192,7 @@ export class AgentTurnController {
         executionScope: params.executionScope,
         artifactContextRef: params.artifactContextRef,
         artifactTaskRef: params.artifactTaskRef,
+        skillConnectorGrants: params.skillConnectorGrants,
         localDeviceGrant: params.localDeviceGrant,
         deviceGrants: params.deviceGrants,
         deviceSelection: params.deviceSelection,
@@ -334,6 +337,7 @@ export class AgentTurnController {
     executionScope?: ExecutionScope;
     artifactContextRef?: string;
     artifactTaskRef?: string;
+    skillConnectorGrants?: SkillConnectorGrant[];
     localDeviceGrant?: ScopedLocalDeviceGrant;
     deviceGrants?: ScopedDeviceGrant[];
     deviceSelection?: ScopedDeviceSelection;
@@ -387,6 +391,7 @@ export class AgentTurnController {
           executionScope: options.executionScope,
           artifactContextRef: options.artifactContextRef,
           artifactTaskRef: options.artifactTaskRef,
+          skillConnectorGrants: options.skillConnectorGrants,
           localDeviceGrant: options.localDeviceGrant,
           deviceGrants: options.deviceGrants,
           deviceSelection: options.deviceSelection,

--- a/src/core/conversation-runner.ts
+++ b/src/core/conversation-runner.ts
@@ -148,6 +148,7 @@ export interface PendingUserInput {
   content: string | ContentBlock[];
   /** Replaces the current turn's short-lived Artifact context ref when present, including explicit undefined. */
   artifactContextRef?: string;
+  skillConnectorGrants?: import('../types/session-identity').SkillConnectorGrant[];
   deviceGrants?: ScopedDeviceGrant[];
   deviceSelection?: ScopedDeviceSelection;
   targetRoutes?: TargetRoutes;
@@ -815,6 +816,12 @@ export class ConversationRunner {
         ],
       };
       shouldRefreshRuntimeContext = true;
+    }
+    if (isPendingUserInput(pending) && pending.skillConnectorGrants?.length) {
+      this.toolExecutionContext = {
+        ...(this.toolExecutionContext || {}),
+        skillConnectorGrants: pending.skillConnectorGrants,
+      };
     }
     if (isPendingUserInput(pending) && pending.deviceSelection) {
       this.toolExecutionContext = {

--- a/src/core/conversation-runner.ts
+++ b/src/core/conversation-runner.ts
@@ -36,6 +36,7 @@ import {
   isLegacyArtifactObservationMessage,
 } from './runtime-context-builder';
 import { buildPendingUserInputBoundaryMessage } from './pending-user-input-boundary';
+import { mergeSkillConnectorGrants } from '../catscompany/skill-connector-grants';
 import {
   TRANSIENT_CURRENT_DIRECTORY_PREFIX,
   buildTransientEnvironmentHint,
@@ -818,9 +819,15 @@ export class ConversationRunner {
       shouldRefreshRuntimeContext = true;
     }
     if (isPendingUserInput(pending) && pending.skillConnectorGrants?.length) {
+      // Union with the live turn's grants so a mid-turn message for one Skill
+      // does not drop a still-valid grant for another; the fresher grant wins
+      // for the same provider + Skill.
       this.toolExecutionContext = {
         ...(this.toolExecutionContext || {}),
-        skillConnectorGrants: pending.skillConnectorGrants,
+        skillConnectorGrants: mergeSkillConnectorGrants([
+          ...(this.toolExecutionContext?.skillConnectorGrants || []),
+          ...pending.skillConnectorGrants,
+        ]),
       };
     }
     if (isPendingUserInput(pending) && pending.deviceSelection) {

--- a/src/tools/bash-tool.ts
+++ b/src/tools/bash-tool.ts
@@ -11,6 +11,7 @@ import { withArtifactTaskRefEnvironment } from '../utils/artifact-task-ref';
 import { resolveRuntimeEnvironment } from '../utils/runtime-environment';
 import { isToolAllowed, isBashCommandAllowed } from '../utils/safety';
 import { executeRouteIfRemote, resolveExecutionRoute, targetParameterDescription } from './execution-router';
+import { withTrustedBotSkillConnectorEnvironment } from '../bot-skills/trusted-script-execution';
 
 const execAsync = promisify(exec);
 const CWD_MARKER_PREFIX = '__XIAOBA_CWD_MARKER__';
@@ -168,9 +169,14 @@ export class ShellTool implements Tool {
       env: process.env,
       probeVersion: false,
     });
+    const isolatedEnvironment = withTrustedBotSkillConnectorEnvironment(
+      trustedSkillScript,
+      context,
+      runtimeEnvironment.env,
+    );
     const commandEnvironment = withArtifactTaskRefEnvironment(
       withArtifactContextRefEnvironment(
-        runtimeEnvironment.env,
+        isolatedEnvironment,
         context.artifactContextRef,
       ),
       context.artifactTaskRef,

--- a/src/types/session-identity.ts
+++ b/src/types/session-identity.ts
@@ -55,6 +55,18 @@ export interface ExecutionScope {
   isTrusted: boolean;
 }
 
+/**
+ * Opaque, short-lived connector capability delivered only with one trusted
+ * CatsCo turn. It must never be rendered into model context or persisted.
+ */
+export interface SkillConnectorGrant {
+  provider: string;
+  skillId: string;
+  connectorUrl: string;
+  actorToken: string;
+  expiresAt: number;
+}
+
 export interface SessionIdentitySnapshot {
   source: MessageSource;
   topicId: string;

--- a/src/types/tool.ts
+++ b/src/types/tool.ts
@@ -5,6 +5,7 @@ import type {
   ScopedDeviceSelection,
   ScopedLocalDeviceGrant,
   ScopedLocalFileGrant,
+  SkillConnectorGrant,
 } from './session-identity';
 import type { PlanRuntime, RuntimePlanSnapshot } from '../core/plan-runtime';
 import type { AIService } from '../utils/ai-service';
@@ -235,6 +236,8 @@ export interface ToolExecutionContext {
    * arguments or a remote device request.
    */
   turnSkillSnapshot?: TurnSkillSnapshotLease;
+  /** Trusted per-turn connector capabilities, scoped to exact SkillHub package ids. */
+  skillConnectorGrants?: SkillConnectorGrant[];
   /** 平台通道回调（飞书/CatsCompany 等聊天会话时由平台层注入） */
   channel?: ChannelCallbacks;
   /** 当前 turn 的可信执行身份；后续 ToolGateway/设备授权会基于它做权限判断。 */

--- a/tests/catscompany-execution-scope-flow.test.ts
+++ b/tests/catscompany-execution-scope-flow.test.ts
@@ -57,6 +57,16 @@ function deviceGrant(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function skillConnectorGrant(provider: string, skillId: string, actorToken: string) {
+  return {
+    provider,
+    skillId,
+    connectorUrl: 'https://app.catsco.cc',
+    actorToken,
+    expiresAt: Date.now() + 60_000,
+  };
+}
+
 function metadataWithDeviceGrants(actorUserId: string, topicId: string, grants: unknown[], agentId = 'usr43', bodyId = 'body-main') {
   const metadata = canonicalMetadata(actorUserId, topicId, agentId, bodyId);
   (metadata.catsco_identity as any).device_grants = grants;
@@ -1669,6 +1679,49 @@ describe('CatsCompany execution scope flow', () => {
     assert.equal(pending.content, '补充读取文件');
     assert.equal(pending.deviceGrants.length, 1);
     assert.equal(pending.deviceGrants[0].deviceId, 'alice-laptop');
+  });
+
+  test('merges Skill connector grants across a queued CatsCompany batch', () => {
+    const { bot } = createHarness();
+    const scope = createExecutionScope(createCatsCoMessageEnvelope({
+      topic: 'p2p_7_43',
+      senderId: 'usr7',
+      text: 'first',
+      metadata: canonicalMetadata('usr7', 'p2p_7_43'),
+      botUid: 'usr43',
+    }));
+
+    bot.messageQueue.set(scope.sessionKey, [{
+      userMessage: '先读石墨',
+      topic: 'p2p_7_43',
+      senderId: 'usr7',
+      seq: 13,
+      executionScope: scope,
+      skillConnectorGrants: [skillConnectorGrant('shimo', 'catsco/shimo-reader', 'token-1')],
+      receivedAt: Date.now(),
+      source: 'user',
+    }, {
+      userMessage: '再读第二张表',
+      topic: 'p2p_7_43',
+      senderId: 'usr7',
+      seq: 14,
+      executionScope: scope,
+      skillConnectorGrants: [
+        skillConnectorGrant('shimo', 'catsco/shimo-reader', 'token-2'),
+        skillConnectorGrant('shimo', 'catsco/project-table', 'token-3'),
+      ],
+      receivedAt: Date.now() + 1,
+      source: 'user',
+    }]);
+
+    const pending = (bot as any).consumeQueuedUserInput(scope.sessionKey, scope);
+    assert.equal(typeof pending, 'object');
+    // The second message refreshes shimo-reader and adds project-table; the
+    // first message's grant must not win merely because it arrived earlier.
+    assert.deepEqual(
+      pending.skillConnectorGrants.map((grant: any) => [grant.skillId, grant.actorToken]),
+      [['catsco/shimo-reader', 'token-2'], ['catsco/project-table', 'token-3']],
+    );
   });
 
   test('uses the latest queued Artifact context ref and can explicitly clear the previous one', () => {

--- a/tests/catscompany-skill-connector-grants.test.ts
+++ b/tests/catscompany-skill-connector-grants.test.ts
@@ -42,6 +42,62 @@ describe('CatsCo Skill connector grants', () => {
       },
     }, trustedScope(), now), []);
   });
+
+  test('validates every scanned grant before applying the keep-limit', () => {
+    const now = Date.now();
+    const valid = Array.from({ length: 5 }, (_, index) => ({
+      provider: 'shimo',
+      skill_id: `catsco/reader-${index}`,
+      connector_url: 'https://app.catsco.test',
+      actor_token: `opaque-turn-token-${index}`,
+      expires_at: new Date(now + 60_000).toISOString(),
+    }));
+
+    const grants = extractCatsCoSkillConnectorGrants({
+      catsco_skill_connectors: {
+        schema: 'catsco.skill_connectors.v1',
+        grants: [null, { provider: 'not a provider!' }, ...valid],
+      },
+    }, trustedScope(), now);
+
+    // Two malformed leading entries must not consume the four-grant budget.
+    assert.deepEqual(grants.map(grant => grant.skillId), [
+      'catsco/reader-0',
+      'catsco/reader-1',
+      'catsco/reader-2',
+      'catsco/reader-3',
+    ]);
+  });
+
+  test('lets a later grant supersede an earlier one for the same provider and Skill', () => {
+    const now = Date.now();
+    const base = {
+      provider: 'shimo',
+      skill_id: 'catsco/shimo-reader',
+      connector_url: 'https://app.catsco.test',
+      expires_at: new Date(now + 60_000).toISOString(),
+    };
+
+    const grants = extractCatsCoSkillConnectorGrants({
+      catsco_skill_connectors: {
+        schema: 'catsco.skill_connectors.v1',
+        grants: [
+          { ...base, actor_token: 'stale-token' },
+          { ...base, actor_token: 'fresh-token' },
+          {
+            ...base,
+            skill_id: 'catsco/project-table',
+            actor_token: 'other-skill-token',
+          },
+        ],
+      },
+    }, trustedScope(), now);
+
+    assert.deepEqual(
+      grants.map(grant => [grant.skillId, grant.actorToken]),
+      [['catsco/shimo-reader', 'fresh-token'], ['catsco/project-table', 'other-skill-token']],
+    );
+  });
 });
 
 function connectorMetadata(expiresAt: number): Record<string, unknown> {

--- a/tests/catscompany-skill-connector-grants.test.ts
+++ b/tests/catscompany-skill-connector-grants.test.ts
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { extractCatsCoSkillConnectorGrants } from '../src/catscompany/skill-connector-grants';
+import type { ExecutionScope } from '../src/types/session-identity';
+
+describe('CatsCo Skill connector grants', () => {
+  test('accepts a live grant only under a trusted canonical CatsCo scope', () => {
+    const now = Date.now();
+    const metadata = connectorMetadata(now + 60_000);
+    const grants = extractCatsCoSkillConnectorGrants(metadata, trustedScope(), now);
+
+    assert.deepEqual(grants, [{
+      provider: 'shimo',
+      skillId: 'catsco/shimo-reader',
+      connectorUrl: 'https://app.catsco.test',
+      actorToken: 'opaque-turn-token',
+      expiresAt: now + 60_000,
+    }]);
+  });
+
+  test('rejects grants from untrusted messages, expired grants, and unsafe connector URLs', () => {
+    const now = Date.now();
+    assert.deepEqual(extractCatsCoSkillConnectorGrants(
+      connectorMetadata(now + 60_000),
+      { ...trustedScope(), isTrusted: false, identityTrust: 'untrusted' },
+      now,
+    ), []);
+    assert.deepEqual(extractCatsCoSkillConnectorGrants(
+      connectorMetadata(now - 1), trustedScope(), now,
+    ), []);
+    assert.deepEqual(extractCatsCoSkillConnectorGrants({
+      ...connectorMetadata(now + 60_000),
+      catsco_skill_connectors: {
+        schema: 'catsco.skill_connectors.v1',
+        grants: [{
+          provider: 'shimo',
+          skill_id: 'catsco/shimo-reader',
+          connector_url: 'http://attacker.example',
+          actor_token: 'opaque-turn-token',
+          expires_at: new Date(now + 60_000).toISOString(),
+        }],
+      },
+    }, trustedScope(), now), []);
+  });
+});
+
+function connectorMetadata(expiresAt: number): Record<string, unknown> {
+  return {
+    catsco_skill_connectors: {
+      schema: 'catsco.skill_connectors.v1',
+      grants: [{
+        provider: 'shimo',
+        skill_id: 'catsco/shimo-reader',
+        connector_url: 'https://app.catsco.test',
+        actor_token: 'opaque-turn-token',
+        expires_at: new Date(expiresAt).toISOString(),
+      }],
+    },
+  };
+}
+
+function trustedScope(): ExecutionScope {
+  return {
+    source: 'catscompany',
+    sessionKey: 'cats:p2p:p2p_7_43:actor:usr7:agent:usr43',
+    topicId: 'p2p_7_43',
+    topicType: 'p2p',
+    actorUserId: 'usr7',
+    agentId: 'usr43',
+    agentBodyId: 'body-cloud',
+    identityTrust: 'server_canonical',
+    isTrusted: true,
+  };
+}

--- a/tests/conversation-runner-pending-input.test.ts
+++ b/tests/conversation-runner-pending-input.test.ts
@@ -6,7 +6,7 @@ import { TRANSIENT_RUNTIME_CONTEXT_PREFIX } from '../src/core/runtime-context-bu
 import { TRANSIENT_PENDING_USER_INPUT_PREFIX } from '../src/core/pending-user-input-boundary';
 import { TurnContextBuilder } from '../src/core/turn-context-builder';
 import { Message } from '../src/types';
-import type { ExecutionScope, ScopedDeviceGrant, ScopedLocalFileGrant } from '../src/types/session-identity';
+import type { ExecutionScope, ScopedDeviceGrant, ScopedLocalFileGrant, SkillConnectorGrant } from '../src/types/session-identity';
 import { ToolCall, ToolDefinition, ToolExecutionContext, ToolExecutor, ToolResult } from '../src/types/tool';
 
 const usage = { promptTokens: 1, completionTokens: 1, totalTokens: 2 };
@@ -93,6 +93,16 @@ function deviceGrant(deviceId: string): ScopedDeviceGrant {
     operations: ['read_file'],
     createdAt: now,
     expiresAt: now + 60_000,
+  };
+}
+
+function skillConnectorGrant(provider: string, skillId: string, actorToken: string): SkillConnectorGrant {
+  return {
+    provider,
+    skillId,
+    connectorUrl: 'https://app.catsco.cc',
+    actorToken,
+    expiresAt: Date.now() + 60_000,
   };
 }
 
@@ -459,6 +469,84 @@ describe('ConversationRunner pending input', () => {
     assert.doesNotMatch(refreshedContent, /device-pending/);
     assert.doesNotMatch(refreshedContext.content as string, /install:device-/);
     assert.doesNotMatch(refreshedContext.content as string, /body-main/);
+  });
+
+  test('unions pending Skill connector grants with the live turn and refreshes only the matching Skill', async () => {
+    const requests: Message[][] = [];
+    const aiService = {
+      chat: async (messages: Message[]) => {
+        requests.push(messages.map(msg => ({ ...msg })));
+        if (requests.length === 1) {
+          return {
+            content: null,
+            toolCalls: [{
+              id: 'call_1',
+              type: 'function',
+              function: { name: 'noop', arguments: '{}' },
+            }],
+            usage,
+          };
+        }
+        if (requests.length === 2) {
+          return {
+            content: null,
+            toolCalls: [{
+              id: 'call_2',
+              type: 'function',
+              function: { name: 'noop', arguments: '{}' },
+            }],
+            usage,
+          };
+        }
+        return { content: 'done', toolCalls: [], usage };
+      },
+    } as any;
+    const contexts: Array<Partial<ToolExecutionContext> | undefined> = [];
+    const executor: ToolExecutor = {
+      getToolDefinitions: () => [{
+        name: 'noop',
+        description: 'noop',
+        parameters: { type: 'object', properties: {} },
+      }],
+      executeTool: async (toolCall, _history, contextOverrides) => {
+        contexts.push(contextOverrides);
+        return {
+          tool_call_id: toolCall.id,
+          role: 'tool',
+          name: toolCall.function.name,
+          content: 'ok',
+          ok: true,
+        };
+      },
+    };
+
+    let pendingUsed = false;
+    const liveShimo = skillConnectorGrant('shimo', 'catsco/shimo-reader', 'shimo-stale');
+    const liveTable = skillConnectorGrant('shimo', 'catsco/project-table', 'table-live');
+    const freshShimo = skillConnectorGrant('shimo', 'catsco/shimo-reader', 'shimo-fresh');
+    const runner = new ConversationRunner(aiService, executor, {
+      stream: false,
+      toolExecutionContext: {
+        skillConnectorGrants: [liveShimo, liveTable],
+      },
+      pendingUserInputProvider: () => {
+        if (pendingUsed) return null;
+        pendingUsed = true;
+        return {
+          content: 'refreshed connector grant while busy',
+          skillConnectorGrants: [freshShimo],
+        };
+      },
+    });
+
+    const result = await runner.run([{ role: 'user', content: 'run a tool' }]);
+
+    assert.equal(result.response, 'done');
+    assert.equal(contexts.length, 2);
+    assert.deepEqual(contexts[0]?.skillConnectorGrants, [liveShimo, liveTable]);
+    // The refreshed grant replaces the stale one for the same Skill; the
+    // unrelated Skill is still live for later tools in the turn.
+    assert.deepEqual(contexts[1]?.skillConnectorGrants, [freshShimo, liveTable]);
   });
 });
 

--- a/tests/trusted-bot-skill-script-execution.test.ts
+++ b/tests/trusted-bot-skill-script-execution.test.ts
@@ -9,7 +9,10 @@ import {
   scanLocalBotSkill,
   writeBotSkillLocalMarker,
 } from '../src/bot-skills/local-manifest';
-import { resolveTrustedBotSkillScriptInvocation } from '../src/bot-skills/trusted-script-execution';
+import {
+  resolveTrustedBotSkillScriptInvocation,
+  withTrustedBotSkillConnectorEnvironment,
+} from '../src/bot-skills/trusted-script-execution';
 import { writeSkillHubInstallMarker } from '../src/skillhub/install-marker';
 import { TurnSkillSnapshotStore } from '../src/skills/turn-skill-snapshot';
 import { ShellTool } from '../src/tools/bash-tool';
@@ -45,7 +48,9 @@ describe('trusted Bot Skill script execution', () => {
     fs.writeFileSync(scriptPath, [
       "import fs from 'node:fs';",
       "const output = process.argv[2];",
-      "fs.writeFileSync(output, JSON.stringify(process.argv.slice(3)), 'utf8');",
+      "const input = process.argv.slice(3);",
+      "const value = input[0] === 'capture-env' ? { connector: process.env.CATSCO_SHIMO_CONNECTOR_URL, token: process.env.CATSCO_ACTOR_TOKEN, skillId: process.env.CATSCO_SKILL_ID } : input;",
+      "fs.writeFileSync(output, JSON.stringify(value), 'utf8');",
       "console.log('verified-skill-ok');",
       '',
     ].join('\n'), 'utf8');
@@ -148,6 +153,58 @@ describe('trusted Bot Skill script execution', () => {
     const result = await new ShellTool().execute({ command, target: 'Alice' }, catsContext());
     assert.equal(result.ok, false);
     assert.equal(result.ok ? '' : result.errorCode, 'TARGET_NOT_FOUND');
+  });
+
+  test('injects a live connector grant only into its exact verified SkillHub package', async () => {
+    const output = path.join(workspaceRoot, 'connector-env.json');
+    const context = catsContext({
+      skillConnectorGrants: [{
+        provider: 'shimo',
+        skillId: reference.skillId,
+        connectorUrl: 'https://app.catsco.test',
+        actorToken: 'turn-scoped-secret',
+        expiresAt: Date.now() + 60_000,
+      }],
+    });
+    const result = await new ShellTool().execute({
+      command: `node "${scriptPath}" "${output}" capture-env`,
+    }, context);
+
+    assert.equal(result.ok, true);
+    assert.deepEqual(JSON.parse(fs.readFileSync(output, 'utf8')), {
+      connector: 'https://app.catsco.test',
+      token: 'turn-scoped-secret',
+      skillId: reference.skillId,
+    });
+  });
+
+  test('strips connector secrets from ordinary commands and non-matching Skills', () => {
+    const environment = {
+      CATSCO_SHIMO_CONNECTOR_URL: 'https://stale.example',
+      CATSCO_ACTOR_TOKEN: 'stale-secret',
+      CATSCO_SKILL_ID: 'stale/skill',
+      SAFE_VALUE: 'kept',
+    };
+    const unrelated = withTrustedBotSkillConnectorEnvironment({
+      scriptPath,
+      args: [scriptPath],
+      skillId: 'another/skill',
+      skillName: 'Another skill',
+      version: '1.0.0',
+    }, catsContext({
+      skillConnectorGrants: [{
+        provider: 'shimo',
+        skillId: reference.skillId,
+        connectorUrl: 'https://app.catsco.test',
+        actorToken: 'turn-scoped-secret',
+        expiresAt: Date.now() + 60_000,
+      }],
+    }), environment);
+
+    assert.equal(unrelated.CATSCO_SHIMO_CONNECTOR_URL, undefined);
+    assert.equal(unrelated.CATSCO_ACTOR_TOKEN, undefined);
+    assert.equal(unrelated.CATSCO_SKILL_ID, undefined);
+    assert.equal(unrelated.SAFE_VALUE, 'kept');
   });
 
   test('rejects a verified package that is not enabled for the active Bot', async () => {


### PR DESCRIPTION
XiaoBa needs to invoke a cloud connector from one approved SkillHub package without exposing the connector credential to the shared runtime, ordinary shell commands, or other Skills.

This parses server-canonical, short-lived CatsCo connector grants as private per-turn state and carries them through immediate and queued conversation paths. The trusted Skill script runner clears connector variables from the shared environment, then injects them only into the exact enabled, integrity-verified SkillHub Node.js package whose ID matches the grant.

The change is connector-generic at the runtime boundary and does not add a Shimo-specific XiaoBa Tool. The matching CatsCo issuance, login, Worker, and auto-resume implementation is reviewed in buildsense-ai/cats-company#439.

Validation:
- `npm run build`
- focused connector-grant and trusted Skill execution tests (12 passing)
- full runtime suite previously reached 1884 passing, 17 skipped, with one unrelated Windows environment failure because `jq` is unavailable
