### PR TITLE
fix: isolate local-only Skills from model updates

### DIFF
--- a/src/bot-definition/activation.ts
+++ b/src/bot-definition/activation.ts
@@ -51,10 +51,17 @@ export interface PrepareBoundBotDefinitionOptions extends BotDefinitionSyncServi
   preserveSkills?: boolean;
   /**
    * The desired Skill references are identical to the last locally active
-   * definition. Reuse that already-applied Skill dimension without scanning or
-   * mutating the workspace while a model/prompt-only revision is activated.
+   * definition. Reuse that already-applied Skill dimension after verifying
+   * workspace ownership, Base metadata, and local package hashes.
    */
   reuseAppliedSkills?: boolean;
+  /**
+   * A hot-reload caller proved that both the previous and desired Definitions
+   * explicitly contain no synchronized Skill references. Preserve any
+   * local-only workspace without treating it as a synchronized Skill package.
+   * This escape hatch is valid only while the desired Skill list stays empty.
+   */
+  skipUnchangedEmptySkills?: boolean;
   /** Hot reload must not silently fall back to legacy/local startup after a failed cloud read. */
   requireCloud?: boolean;
 }
@@ -243,9 +250,15 @@ export async function prepareBoundBotDefinition(
           )
         );
         const desiredRevision = cloudSnapshot.revision;
+        const skipUnchangedEmptySkills = Boolean(
+          options.skipUnchangedEmptySkills
+          && cloudSnapshot.definition?.skills
+          && cloudSnapshot.definition.skills.length === 0
+        );
         const skillSync = (
           options.prepareSkills === false
           || options.preserveSkills
+          || skipUnchangedEmptySkills
         )
           ? undefined
           : await prepareBoundBotSkills({
@@ -272,6 +285,7 @@ export async function prepareBoundBotDefinition(
         );
         const targetRevisionApplied = (
           options.preserveSkills
+          || skipUnchangedEmptySkills
           || skippedSkillsAreAbsent
           || Boolean(
             skillSync

--- a/src/bot-definition/activation.ts
+++ b/src/bot-definition/activation.ts
@@ -59,9 +59,11 @@ export interface PrepareBoundBotDefinitionOptions extends BotDefinitionSyncServi
    * A hot-reload caller proved that both the previous and desired Definitions
    * explicitly contain no synchronized Skill references. Preserve any
    * local-only workspace without treating it as a synchronized Skill package.
-   * This escape hatch is valid only while the desired Skill list stays empty.
+   * The workspace is still activated for this Bot so the ownership invariant
+   * from the strict path keeps holding. This escape hatch is valid only while
+   * the desired Skill list stays empty.
    */
-  skipUnchangedEmptySkills?: boolean;
+  preserveLocalOnlySkills?: boolean;
   /** Hot reload must not silently fall back to legacy/local startup after a failed cloud read. */
   requireCloud?: boolean;
 }
@@ -250,16 +252,18 @@ export async function prepareBoundBotDefinition(
           )
         );
         const desiredRevision = cloudSnapshot.revision;
-        const skipUnchangedEmptySkills = Boolean(
-          options.skipUnchangedEmptySkills
-          && cloudSnapshot.definition?.skills
-          && cloudSnapshot.definition.skills.length === 0
+        // Ownership is never part of the escape hatch: the workspace is still
+        // activated for this Bot, only the Cloud package reconciliation is
+        // skipped.
+        const preserveLocalOnlySkills = Boolean(
+          options.preserveLocalOnlySkills
+          && previouslyActiveDefinition?.skills?.length === 0
+          && cloudSnapshot.definition?.skills?.length === 0
         );
-        const skillSync = (
-          options.prepareSkills === false
-          || options.preserveSkills
-          || skipUnchangedEmptySkills
-        )
+        const skillsManagedOutsidePreparation = (
+          options.prepareSkills === false || options.preserveSkills
+        );
+        const skillSync = skillsManagedOutsidePreparation
           ? undefined
           : await prepareBoundBotSkills({
               runtimeRoot: options.runtimeRoot,
@@ -267,6 +271,9 @@ export async function prepareBoundBotDefinition(
               auth,
               fetchImpl: options.fetchImpl,
               definitionService,
+              ...(preserveLocalOnlySkills
+                ? { preserveLocalOnlyWorkspace: { definitionRevision: desiredRevision } }
+                : {}),
               ...(reuseAppliedSkills && cloudSnapshot.definition?.skills
                 ? {
                     reuseVerifiedLocal: {
@@ -285,7 +292,7 @@ export async function prepareBoundBotDefinition(
         );
         const targetRevisionApplied = (
           options.preserveSkills
-          || skipUnchangedEmptySkills
+          || (preserveLocalOnlySkills && options.prepareSkills === false)
           || skippedSkillsAreAbsent
           || Boolean(
             skillSync

--- a/src/bot-skills/runtime.ts
+++ b/src/bot-skills/runtime.ts
@@ -37,6 +37,16 @@ export interface PrepareBoundBotSkillsOptions {
     skills: readonly BotSkillRef[];
     definitionRevision: number;
   };
+  /**
+   * The caller proved that the previous and desired BotDefinitions both list no
+   * synchronized Skill references. Activate this Bot's workspace so the
+   * ownership invariant still holds (a foreign workspace gets parked and this
+   * Bot's own workspace is restored), but skip Cloud package reconciliation so
+   * local-only content is neither read, uploaded, nor deleted.
+   */
+  preserveLocalOnlyWorkspace?: {
+    definitionRevision: number;
+  };
 }
 
 export interface PreparedBoundBotSkills {
@@ -117,6 +127,23 @@ export async function prepareBoundBotSkills(
         BotSkillSyncService.recoverInterruptedRestore(runtimeRoot, activeBotId, activeRoot);
       }
       activation = workspace.activate(options.botId);
+      if (options.preserveLocalOnlyWorkspace) {
+        const revision = options.preserveLocalOnlyWorkspace.definitionRevision;
+        return {
+          sync: {
+            botId: options.botId,
+            direction: 'none',
+            cloudRevision: revision,
+            observedRevision: revision,
+            desiredRevision: revision,
+            appliedRevision: revision,
+            applyStatus: 'already_applied',
+            skills: [],
+          },
+          workspaceExisted: activation.existed,
+          activation,
+        };
+      }
       const syncService = new BotSkillSyncService({
         runtimeRoot,
         botId: options.botId,

--- a/src/commands/catscompany.ts
+++ b/src/commands/catscompany.ts
@@ -471,6 +471,13 @@ async function applyCloudBotDefinitionSelection(
     && effectiveIncoming.skills !== undefined
     && botSkillRefsEqual(previousDefinition.skills, effectiveIncoming.skills)
   );
+  const skipUnchangedEmptySkills = Boolean(
+    previousDefinition
+    && previousDefinition.skills !== undefined
+    && effectiveIncoming?.skills
+    && effectiveIncoming.skills.length === 0
+    && botSkillRefsEqual(previousDefinition.skills, effectiveIncoming.skills)
+  );
   const queuedModelChanged = !previousDefinition
     || !effectiveIncoming
     || JSON.stringify(previousDefinition.model) !== JSON.stringify(effectiveIncoming.model);
@@ -517,6 +524,7 @@ async function applyCloudBotDefinitionSelection(
       acknowledgeCloudSelection: false,
       preserveSkills,
       reuseAppliedSkills,
+      skipUnchangedEmptySkills,
       requireCloud: true,
     });
   } catch (error) {

--- a/src/commands/catscompany.ts
+++ b/src/commands/catscompany.ts
@@ -471,7 +471,7 @@ async function applyCloudBotDefinitionSelection(
     && effectiveIncoming.skills !== undefined
     && botSkillRefsEqual(previousDefinition.skills, effectiveIncoming.skills)
   );
-  const skipUnchangedEmptySkills = Boolean(
+  const preserveLocalOnlySkills = Boolean(
     previousDefinition
     && previousDefinition.skills !== undefined
     && effectiveIncoming?.skills
@@ -524,7 +524,7 @@ async function applyCloudBotDefinitionSelection(
       acknowledgeCloudSelection: false,
       preserveSkills,
       reuseAppliedSkills,
-      skipUnchangedEmptySkills,
+      preserveLocalOnlySkills,
       requireCloud: true,
     });
   } catch (error) {

--- a/tests/cloud-bot-model-apply-retry.test.ts
+++ b/tests/cloud-bot-model-apply-retry.test.ts
@@ -311,6 +311,197 @@ test('post-start prompt-only updates reuse unchanged Skills without restarting t
   assert.deepEqual(definitions.read('43')?.prompt, desired.prompt);
 });
 
+test('model-only updates keep an unverified local-only workspace when synchronized Skill refs stay empty', async t => {
+  const runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'model-apply-local-only-skills-'));
+  t.after(() => fs.rmSync(runtimeRoot, { recursive: true, force: true }));
+  const configService = createCatsCoLocalConfigService({ runtimeRoot });
+  configService.save({
+    version: 1,
+    endpoints: { httpBaseUrl: 'https://cats.example.test', serverUrl: 'wss://cats.example.test/v0/channels' },
+    account: { token: 'test-owner-token', uid: '7' },
+    currentBot: { uid: '43', apiKey: 'test-bot-key', boundByUserUid: '7', bindingSource: 'test' },
+  });
+  const auth = configService.getAuthState();
+  const definitions = createBotDefinitionSyncService({ runtimeRoot });
+  const previous: BotDefinition = {
+    schema: BOT_DEFINITION_SCHEMA,
+    botId: '43',
+    model: {
+      kind: 'custom', protocol: 'openai-responses', apiBase: 'https://models.example.test/v1',
+      model: 'previous-model', apiKey: 'test-model-key', contextWindowTokens: 128000,
+    },
+    prompt: { selected: 'custom', customSystemPrompt: 'Unchanged prompt.' },
+    skills: [],
+  };
+  const desired: BotDefinition = {
+    ...previous,
+    model: { ...previous.model, model: 'next-model' },
+  };
+  definitions.acceptCanonical(previous);
+  const localSkillRoot = path.join(runtimeRoot, 'skills', 'server-local');
+  const localSkillFile = path.join(localSkillRoot, 'SKILL.md');
+  fs.mkdirSync(localSkillRoot, { recursive: true });
+  fs.writeFileSync(localSkillFile, [
+    '---',
+    'name: server-local',
+    'description: Local-only Skill without historical Base metadata.',
+    '---',
+    '',
+    'Keep this content.',
+    '',
+  ].join('\n'));
+  new BotSkillWorkspaceService(runtimeRoot).activate('43');
+  assert.equal(new BotSkillBaseStore(runtimeRoot).read('43'), undefined);
+  const before = fs.readFileSync(localSkillFile, 'utf8');
+
+  const requests: string[] = [];
+  const acks: unknown[] = [];
+  t.mock.method(globalThis, 'fetch', async (input: string | URL | Request, init?: RequestInit) => {
+    const url = new URL(String(input));
+    const method = init?.method || 'GET';
+    requests.push(`${method} ${url.pathname}`);
+    if (url.pathname === '/api/bot/definition' && method === 'GET') {
+      return Response.json({ configured: true, revision: 7, definition: desired });
+    }
+    if (url.pathname === '/api/bot/definition/ack' && method === 'POST') {
+      acks.push(JSON.parse(String(init?.body)));
+      return Response.json({ status: 'applied' });
+    }
+    if (url.pathname === '/api/bot/definition/default-prompt') {
+      return Response.json({ status: 'stored' });
+    }
+    throw new Error(`Unexpected test request: ${method} ${url.pathname}`);
+  });
+  let stopped = 0;
+  let started = 0;
+  const oldBot = {
+    isIdleForRuntimeReload: () => true,
+    destroy: async () => { stopped += 1; },
+  } as CatsCompanyBot;
+  let bot = oldBot;
+  t.mock.method(CatsCompanyBot.prototype, 'start', async function (this: CatsCompanyBot) {
+    started += 1;
+    t.after(() => this.destroy());
+  });
+  t.mock.method(CatsCompanyBot.prototype, 'waitUntilReady', async () => {});
+
+  const result = await applyCloudModelRuntimeSelection({
+    runtimeRoot,
+    botId: '43',
+    auth,
+    selection: {
+      kind: 'custom', modelId: 'next-model', customModel: desired.model,
+      revision: 7, definition: desired,
+    },
+    canApply: () => true,
+    connectorConfig: {
+      serverUrl: 'wss://cats.example.test/v0/channels', apiKey: 'test-bot-key', botUid: '43',
+    },
+    currentBot: () => bot,
+    replaceBot: next => { bot = next; },
+    scheduleAckRetry: () => assert.fail('ACK should succeed'),
+    clearAckRetry: () => {},
+  });
+
+  assert.equal(result, 'applied');
+  assert.equal(stopped, 1);
+  assert.equal(started, 1);
+  assert.notEqual(bot, oldBot);
+  assert.deepEqual(acks, [{ revision: 7 }]);
+  assert.equal(requests.some(request => request.includes('/api/bot/definition/skills')), false);
+  assert.equal(requests.some(request => request.includes('private-skill-packages')), false);
+  assert.equal(fs.readFileSync(localSkillFile, 'utf8'), before);
+  assert.equal(new BotSkillWorkspaceService(runtimeRoot).getActiveBotId(), '43');
+  assert.equal(new BotSkillBaseStore(runtimeRoot).read('43'), undefined);
+  assert.deepEqual(definitions.read('43')?.model, desired.model);
+});
+
+test('a change from synchronized Skill refs to empty still requires strict workspace activation', async t => {
+  const runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'model-apply-skill-removal-'));
+  t.after(() => fs.rmSync(runtimeRoot, { recursive: true, force: true }));
+  const configService = createCatsCoLocalConfigService({ runtimeRoot });
+  configService.save({
+    version: 1,
+    endpoints: { httpBaseUrl: 'https://cats.example.test', serverUrl: 'wss://cats.example.test/v0/channels' },
+    account: { token: 'test-owner-token', uid: '7' },
+    currentBot: { uid: '43', apiKey: 'test-bot-key', boundByUserUid: '7', bindingSource: 'test' },
+  });
+  const auth = configService.getAuthState();
+  const definitions = createBotDefinitionSyncService({ runtimeRoot });
+  const previous: BotDefinition = {
+    schema: BOT_DEFINITION_SCHEMA,
+    botId: '43',
+    model: {
+      kind: 'custom', protocol: 'openai-responses', apiBase: 'https://models.example.test/v1',
+      model: 'previous-model', apiKey: 'test-model-key', contextWindowTokens: 128000,
+    },
+    prompt: { selected: 'custom', customSystemPrompt: 'Unchanged prompt.' },
+    skills: [TEST_SKILL_REFERENCE],
+  };
+  const desired: BotDefinition = {
+    ...previous,
+    model: { ...previous.model, model: 'next-model' },
+    skills: [],
+  };
+  definitions.acceptCanonical(previous);
+  const localSkillRoot = path.join(runtimeRoot, 'skills', 'server-local');
+  fs.mkdirSync(localSkillRoot, { recursive: true });
+  fs.writeFileSync(path.join(localSkillRoot, 'SKILL.md'), [
+    '---',
+    'name: server-local',
+    'description: Local workspace that must survive a synchronized Skill removal.',
+    '---',
+    '',
+  ].join('\n'));
+  new BotSkillWorkspaceService(runtimeRoot).activate('43');
+
+  const acks: any[] = [];
+  t.mock.method(globalThis, 'fetch', async (input: string | URL | Request, init?: RequestInit) => {
+    const url = new URL(String(input));
+    const method = init?.method || 'GET';
+    if (url.pathname === '/api/bot/definition' && method === 'GET') {
+      return Response.json({ configured: true, revision: 7, definition: desired });
+    }
+    if (url.pathname === '/api/bot/definition/ack' && method === 'POST') {
+      acks.push(JSON.parse(String(init?.body)));
+      return Response.json({ status: 'failed' });
+    }
+    if (url.pathname === '/api/bot/definition/default-prompt') {
+      return Response.json({ status: 'stored' });
+    }
+    throw new Error(`Unexpected test request: ${method} ${url.pathname}`);
+  });
+  const oldBot = { isIdleForRuntimeReload: () => true } as CatsCompanyBot;
+
+  await assert.rejects(
+    applyCloudModelRuntimeSelection({
+      runtimeRoot,
+      botId: '43',
+      auth,
+      selection: {
+        kind: 'custom', modelId: 'next-model', customModel: desired.model,
+        revision: 7, definition: desired,
+      },
+      canApply: () => true,
+      connectorConfig: {
+        serverUrl: 'wss://cats.example.test/v0/channels', apiKey: 'test-bot-key', botUid: '43',
+      },
+      currentBot: () => oldBot,
+      replaceBot: () => assert.fail('an unverified Skill removal must not replace the connector'),
+      scheduleAckRetry: () => assert.fail('the failure ACK should be delivered'),
+      clearAckRetry: () => {},
+    }),
+    /local_workspace_unverified/,
+  );
+
+  assert.equal(acks.length, 1);
+  assert.equal(acks[0].revision, 7);
+  assert.match(acks[0].error, /local_workspace_unverified/);
+  assert.equal(fs.existsSync(path.join(localSkillRoot, 'SKILL.md')), true);
+  assert.equal(new BotSkillBaseStore(runtimeRoot).read('43'), undefined);
+  assert.deepEqual(definitions.read('43')?.model, previous.model);
+});
+
 test('preparation that advances from a prompt-only revision to a model revision restarts before ACK', async t => {
   const runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'model-apply-advanced-revision-'));
   t.after(() => fs.rmSync(runtimeRoot, { recursive: true, force: true }));

--- a/tests/cloud-bot-model-apply-retry.test.ts
+++ b/tests/cloud-bot-model-apply-retry.test.ts
@@ -502,6 +502,115 @@ test('a change from synchronized Skill refs to empty still requires strict works
   assert.deepEqual(definitions.read('43')?.model, previous.model);
 });
 
+test('model-only updates with empty Skill refs still restore workspace ownership for the bound Bot', async t => {
+  const runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'model-apply-foreign-workspace-'));
+  t.after(() => fs.rmSync(runtimeRoot, { recursive: true, force: true }));
+  const configService = createCatsCoLocalConfigService({ runtimeRoot });
+  configService.save({
+    version: 1,
+    endpoints: { httpBaseUrl: 'https://cats.example.test', serverUrl: 'wss://cats.example.test/v0/channels' },
+    account: { token: 'test-owner-token', uid: '7' },
+    currentBot: { uid: '43', apiKey: 'test-bot-key', boundByUserUid: '7', bindingSource: 'test' },
+  });
+  const auth = configService.getAuthState();
+  const definitions = createBotDefinitionSyncService({ runtimeRoot });
+  const previous: BotDefinition = {
+    schema: BOT_DEFINITION_SCHEMA,
+    botId: '43',
+    model: {
+      kind: 'custom', protocol: 'openai-responses', apiBase: 'https://models.example.test/v1',
+      model: 'previous-model', apiKey: 'test-model-key', contextWindowTokens: 128000,
+    },
+    prompt: { selected: 'custom', customSystemPrompt: 'Unchanged prompt.' },
+    skills: [],
+  };
+  const desired: BotDefinition = {
+    ...previous,
+    model: { ...previous.model, model: 'next-model' },
+  };
+  definitions.acceptCanonical(previous);
+
+  // A previous session left the active workspace owned by another Bot that also
+  // parked local-only Skill content inside it.
+  new BotSkillWorkspaceService(runtimeRoot).activate('99');
+  const foreignSkillRoot = path.join(runtimeRoot, 'skills', 'other-bot-skill');
+  fs.mkdirSync(foreignSkillRoot, { recursive: true });
+  const foreignSkillFile = path.join(foreignSkillRoot, 'SKILL.md');
+  fs.writeFileSync(foreignSkillFile, [
+    '---',
+    'name: other-bot-skill',
+    'description: Local-only Skill that belongs to another Bot.',
+    '---',
+    '',
+    'Another Bot owns this content.',
+    '',
+  ].join('\n'));
+  const before = fs.readFileSync(foreignSkillFile, 'utf8');
+
+  const requests: string[] = [];
+  t.mock.method(globalThis, 'fetch', async (input: string | URL | Request, init?: RequestInit) => {
+    const url = new URL(String(input));
+    const method = init?.method || 'GET';
+    requests.push(`${method} ${url.pathname}`);
+    if (url.pathname === '/api/bot/definition' && method === 'GET') {
+      return Response.json({ configured: true, revision: 7, definition: desired });
+    }
+    if (url.pathname === '/api/bot/definition/ack' && method === 'POST') {
+      return Response.json({ status: 'applied' });
+    }
+    if (url.pathname === '/api/bot/definition/default-prompt') {
+      return Response.json({ status: 'stored' });
+    }
+    throw new Error(`Unexpected test request: ${method} ${url.pathname}`);
+  });
+  let stopped = 0;
+  let started = 0;
+  const oldBot = {
+    isIdleForRuntimeReload: () => true,
+    destroy: async () => { stopped += 1; },
+  } as CatsCompanyBot;
+  let bot = oldBot;
+  t.mock.method(CatsCompanyBot.prototype, 'start', async function (this: CatsCompanyBot) {
+    started += 1;
+    t.after(() => this.destroy());
+  });
+  t.mock.method(CatsCompanyBot.prototype, 'waitUntilReady', async () => {});
+
+  const result = await applyCloudModelRuntimeSelection({
+    runtimeRoot,
+    botId: '43',
+    auth,
+    selection: {
+      kind: 'custom', modelId: 'next-model', customModel: desired.model,
+      revision: 7, definition: desired,
+    },
+    canApply: () => true,
+    connectorConfig: {
+      serverUrl: 'wss://cats.example.test/v0/channels', apiKey: 'test-bot-key', botUid: '43',
+    },
+    currentBot: () => bot,
+    replaceBot: next => { bot = next; },
+    scheduleAckRetry: () => assert.fail('ACK should succeed'),
+    clearAckRetry: () => {},
+  });
+
+  assert.equal(result, 'applied');
+  assert.equal(stopped, 1);
+  assert.equal(started, 1);
+  assert.equal(new BotSkillWorkspaceService(runtimeRoot).getActiveBotId(), '43');
+  assert.equal(fs.existsSync(foreignSkillFile), false);
+  assert.equal(
+    fs.readFileSync(
+      path.join(runtimeRoot, 'data', 'bot-skills', 'workspaces', '99', 'other-bot-skill', 'SKILL.md'),
+      'utf8',
+    ),
+    before,
+  );
+  assert.equal(requests.some(request => request.includes('private-skill-packages')), false);
+  assert.equal(new BotSkillBaseStore(runtimeRoot).read('43'), undefined);
+  assert.deepEqual(definitions.read('43')?.model, desired.model);
+});
+
 test('preparation that advances from a prompt-only revision to a model revision restarts before ACK', async t => {
   const runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'model-apply-advanced-revision-'));
   t.after(() => fs.rmSync(runtimeRoot, { recursive: true, force: true }));


### PR DESCRIPTION
## 问题

服务器上的 Bot 可能拥有大量“仅存在于本机”的 Skill，而其 BotDefinition 的同步 Skill 列表一直明确为 `[]`。这类旧实例通常没有 Skill Base 元数据。

PR #470 加强了 Skill 工作区校验后，模型或提示词的远程更新也会触发这项校验；因此，即使 Skill 维度没有变化，更新仍会以 `local_workspace_unverified` 失败并回滚模型。wjcc 的实际日志就是这一情况。

## 修复

- 当且仅当上一个本地 Definition 和云端目标 Definition 都明确包含相同的空 Skill 列表时，模型/提示词热更新保留本地独有 Skill，不再把它们误判为待同步的 Skill 包。
- 不伪造 Skill Base，也不把本地独有 Skill 标记为已同步。
- 只要同步 Skill 引用新增、删除、改变，或者目标列表不是空列表，仍执行原有严格工作区校验。

## 验证

- 新增真实故障形态回归测试：无 Base、非空本地 Skill 工作区、同步引用始终为空时，模型切换成功，工作区字节不变。
- 新增负向测试：从非空同步 Skill 引用变为空时仍必须严格激活并拒绝未验证工作区。
- 相关 BotDefinition、Skill 激活和模型热更新测试：75 passed。
- `npm run build` 通过。
- 全量 runtime：1872 passed，17 skipped，3 个既有环境失败；同一 `origin/main` 基线上可复现，其中一项缺少 `jq`，另外两项受并行测试清理共享 `dist` 影响。

## 部署与验证顺序

1. 合并并完成 CI/CD。
2. 再将目标服务器更新到包含本 PR 的 main 并重启 XiaoBa。
3. Owner 重新登录 WebApp，切换模型。
4. 以服务器日志和实际对话的模型上下文确认生效；不要只以 UI 选中状态判断。
