### PR TITLE
fix: consume dynamic relay model metadata in legacy config

### DIFF
--- a/src/bot-definition/cloud-client.ts
+++ b/src/bot-definition/cloud-client.ts
@@ -129,10 +129,12 @@ export async function pullLegacyCloudBotModelSelection(
       ...(reasoningEffort ? { reasoningEffort } : {}),
     };
   }
+  const catalogRuntime = parseCloudCatalogRuntime(response?.desired?.runtime);
   return {
     kind: 'catalog',
     modelId,
     revision,
+    ...(catalogRuntime ? { catalogRuntime } : {}),
     ...(parseCloudContextWindowTokens(response?.desired?.context_window_tokens) !== undefined
       ? { contextWindowTokens: parseCloudContextWindowTokens(response?.desired?.context_window_tokens) }
       : {}),
@@ -392,9 +394,10 @@ function parseCloudCatalogRuntime(value: unknown): RelayModelRuntimeDescriptor |
   const contextWindowTokens = Number(input.contextWindowTokens);
   const rawCapabilities = input.capabilities;
   if (!provider || !model || !Number.isInteger(contextWindowTokens)
-    || contextWindowTokens < 1_024 || contextWindowTokens > 4_000_000
-    || !rawCapabilities || typeof rawCapabilities !== 'object') return undefined;
-  const capabilities = rawCapabilities as Record<string, unknown>;
+    || contextWindowTokens < 1_024 || contextWindowTokens > 4_000_000) return undefined;
+  const capabilities = rawCapabilities && typeof rawCapabilities === 'object'
+    ? rawCapabilities as Record<string, unknown>
+    : input;
   if (typeof capabilities.vision !== 'boolean'
     || typeof capabilities.toolCalling !== 'boolean'
     || typeof capabilities.streaming !== 'boolean') return undefined;

--- a/tests/cloud-bot-model-client.test.ts
+++ b/tests/cloud-bot-model-client.test.ts
@@ -362,4 +362,37 @@ describe('cloud bot model client local handoff', () => {
       revision: 10,
     });
   });
+
+  test('reads dynamic relay runtime metadata from the legacy model-config contract', async () => {
+    const selection = await pullCloudBotModelSelection({
+      botId: '43',
+      auth,
+      fetchImpl: (async () => Response.json({
+        uid: 43,
+        configured: true,
+        desired: {
+          kind: 'catalog', model_id: 'deepseek-flash', revision: 11,
+          runtime: {
+            catalogModelId: 'deepseek-flash',
+            model: 'deepseek-flash-openai',
+            provider: 'openai',
+            contextWindowTokens: 1_000_000,
+            openaiApiMode: 'chat_completions',
+            capabilities: { vision: true, toolCalling: true, streaming: true },
+          },
+        },
+      })) as typeof fetch,
+    });
+
+    assert.equal(selection?.kind, 'catalog');
+    assert.equal(selection?.modelId, 'deepseek-flash');
+    assert.deepStrictEqual(selection?.catalogRuntime, {
+      catalogModelId: 'deepseek-flash',
+      model: 'deepseek-flash-openai',
+      provider: 'openai',
+      contextWindowTokens: 1_000_000,
+      openaiApiMode: 'chat_completions',
+      capabilities: { vision: true, toolCalling: true, streaming: true },
+    });
+  });
 });


### PR DESCRIPTION
## Problem
Older XiaoBa workers still use `/api/bot/model-config`. The response can carry authoritative runtime metadata for a newly registered Relay model, but XiaoBa discarded it and fell back to the static local registry, producing `Unknown CatsCo relay model` during runtime switching.

## Change
- Read `desired.runtime` from the legacy cloud model-config contract.
- Accept both nested `capabilities` metadata and the flat server descriptor shape.
- Keep descriptor validation strict; provider, protocol mode, context window, and all capability flags remain required.
- Add regression coverage for a dynamic `deepseek-flash` selection.

## Validation
- `npx tsx --test tests/cloud-bot-model-client.test.ts`
- `npm run build`
- `git diff --check`
