### PR TITLE
fix: preserve local-only Skills when activating from Cloud

### DIFF
--- a/src/bot-skills/local-manifest.ts
+++ b/src/bot-skills/local-manifest.ts
@@ -15,9 +15,19 @@ import type {
 export const BOT_SKILL_LOCAL_MARKER_FILE = '.xiaoba-bot-skill.json';
 
 export class BotSkillPackageValidationError extends Error {
-  constructor(message: string) {
+  /**
+   * Packaged size limits describe the synchronization channel, not the Skill:
+   * a workspace may legitimately hold a Skill that is too large to publish, and
+   * callers that synchronize can skip such an entry instead of failing forever.
+   * Every other failure reports broken content - invalid frontmatter, unsafe
+   * paths, secrets - and must keep failing loudly wherever it is found.
+   */
+  readonly kind: 'content' | 'package-limit';
+
+  constructor(message: string, kind: 'content' | 'package-limit' = 'content') {
     super(message);
     this.name = 'BotSkillPackageValidationError';
+    this.kind = kind;
   }
 }
 
@@ -370,11 +380,14 @@ export function collectBotSkillPackageFiles(
         }
       }
       if (bytes.length > MAX_SINGLE_FILE_BYTES) {
-        throw new BotSkillPackageValidationError(`Skill file is too large: ${relativePath}`);
+        throw new BotSkillPackageValidationError(
+          `Skill file is too large: ${relativePath}`,
+          'package-limit',
+        );
       }
       totalBytes += bytes.length;
       if (totalBytes > MAX_TOTAL_BYTES) {
-        throw new BotSkillPackageValidationError('Skill package is too large');
+        throw new BotSkillPackageValidationError('Skill package is too large', 'package-limit');
       }
       files.push({
         path: relativePath,
@@ -383,7 +396,10 @@ export function collectBotSkillPackageFiles(
         contentBase64: bytes.toString('base64'),
       });
       if (files.length > MAX_FILES) {
-        throw new BotSkillPackageValidationError('Skill package contains too many files');
+        throw new BotSkillPackageValidationError(
+          'Skill package contains too many files',
+          'package-limit',
+        );
       }
     }
   };

--- a/src/bot-skills/sync-service.ts
+++ b/src/bot-skills/sync-service.ts
@@ -225,7 +225,7 @@ export class BotSkillSyncService {
       this.skillsRoot,
     );
     const base = this.baseStore.read(this.botId);
-    let local = this.readSyncableLocalManifest();
+    let local = this.readSyncableLocalManifest(base);
     let cloud: CloudBotSkills | undefined;
     try {
       cloud = await pullCloudBotSkills(this.cloudOptions);
@@ -239,7 +239,7 @@ export class BotSkillSyncService {
     }
 
     this.recoverInterruptedFinalizes(cloud);
-    local = this.readSyncableLocalManifest();
+    local = this.readSyncableLocalManifest(base);
 
     if (!cloud.definition) {
       if (!this.workspaceExisted && base?.skills.length) {
@@ -832,13 +832,28 @@ export class BotSkillSyncService {
    * keeps it on disk. Broken content still fails loudly, and the owner-facing
    * publish paths keep the strict read, because that owner asked to publish this
    * workspace and needs to see the validation error.
+   *
+   * Skipping is only safe for a Skill this Bot's Definition cannot own. A skipped
+   * entry disappears from the local manifest, and pushLocal builds the next
+   * Definition from that manifest plus the Base entries it is told to preserve, so
+   * dropping a Cloud-owned entry here would silently remove its reference from the
+   * Definition and make every other device uninstall it. Without a Base there is
+   * no way to prove the entry is local-only either, so both cases keep failing.
    */
-  private readSyncableLocalManifest(): LocalBotSkillManifestEntry[] {
+  private readSyncableLocalManifest(
+    base: BotSkillSyncBase | undefined,
+  ): LocalBotSkillManifestEntry[] {
     const rejected: BotSkillWorkspaceValidationFailure[] = [];
     const entries = this.readLocalManifest({
       onValidationFailure: failure => rejected.push(failure),
     });
-    assertOnlyPackageLimitsSkipped(rejected);
+    const cloudOwned = new Set(cloudOwnedSkillRoots(this.skillsRoot, base));
+    const blocking = rejected.find(failure => (
+      failure.error.kind !== 'package-limit'
+      || !base
+      || cloudOwned.has(path.resolve(failure.path))
+    ));
+    if (blocking) throw blocking.error;
     reportSkippedLocalSkills(rejected);
     return entries;
   }
@@ -1557,6 +1572,12 @@ function referenceKey(reference: BotSkillRef): string {
  * validator rejects. An unreadable entry cannot be attributed to Cloud, so it is
  * copied through the restore instead of being dropped, and one oversized Skill
  * can no longer fail the whole restore. It is reported so the operator sees it.
+ *
+ * Rejected entries also stay out of the managed set, which is the fail-safe
+ * direction here: copyUnmanagedWorkspaceContent then refuses to let a rejected
+ * Cloud-owned install path overwrite the Skill restored from Cloud (a loud
+ * conflict, never a silent deletion). Routine sync has no such second chance,
+ * which is why readSyncableLocalManifest keeps failing for Cloud-owned entries.
  */
 function scanManageableWorkspaceRoots(skillsRoot: string): string[] {
   const rejected: BotSkillWorkspaceValidationFailure[] = [];

--- a/src/bot-skills/sync-service.ts
+++ b/src/bot-skills/sync-service.ts
@@ -21,13 +21,16 @@ import { BotSkillBaseStore } from './base-store';
 import {
   BOT_SKILL_LOCAL_MARKER_FILE,
   computeBotSkillPackageHash,
+  isPortablePackagePath,
   readBotSkillLocalMarker,
+  scanLocalBotSkill,
   scanBotSkillWorkspace,
   type BotSkillWorkspaceValidationFailure,
   type ScanBotSkillWorkspaceOptions,
   writeBotSkillLocalMarker,
 } from './local-manifest';
 import { BotPrivateSkillClient } from './private-package-client';
+import { Logger } from '../utils/logger';
 import { renameBotSkillWorkspaceSync } from './workspace-fs';
 import { BotSkillWorkspaceService } from './workspace';
 import type {
@@ -333,8 +336,11 @@ export class BotSkillSyncService {
 
   /**
    * Reconciles the formal Skill workspace while a Bot is being activated.
-   * Cloud BotDefinition is the only authority in this path: local changes are
-   * preserved as evidence and are never uploaded or written back to Cloud.
+   * The Cloud BotDefinition is authoritative only for the Skills it owns: local
+   * changes to those Skills are preserved as evidence and are never uploaded or
+   * written back to Cloud. Workspace entries the Definition does not own -
+   * operator managed and user authored Skills, plus stray files such as notes -
+   * are carried into the restored workspace instead of being deleted.
    */
   async reconcileActivationFromCloudOnly(): Promise<BotSkillSyncResult> {
     try {
@@ -456,7 +462,7 @@ export class BotSkillSyncService {
       }
 
       return this.restoreCloud(cloud, {
-        preserveUnmanaged: false,
+        preserveLocalOnlyWorkspace: true,
         pendingSnapshot: {
           reason: localChanged
             ? base ? 'activation_local_changed' : 'activation_without_base'
@@ -1011,6 +1017,16 @@ export class BotSkillSyncService {
   private async restoreCloud(
     cloud: CloudBotSkills,
     options: {
+      /**
+       * Cloud is authoritative for the Skills its own Definition owns. When
+       * set, only the workspace directories Base attributes to this Bot's
+       * Definition may be replaced or removed: operator managed Skills, user
+       * authored Skills and stray files survive the restore. The activation
+       * path needs this because its previous workspace may never have matched
+       * Base, so "every Skill on disk" is not the same set as "every Skill
+       * Cloud owns".
+       */
+      preserveLocalOnlyWorkspace?: boolean;
       preserveUnmanaged?: boolean;
       validateScope?: () => Promise<void> | void;
       pendingSnapshot?: {
@@ -1035,6 +1051,8 @@ export class BotSkillSyncService {
   private async restoreCloudUnchecked(
     cloud: CloudBotSkills,
     options: {
+      /** See restoreCloud: keep workspace entries this Bot's Definition does not own. */
+      preserveLocalOnlyWorkspace?: boolean;
       preserveUnmanaged?: boolean;
       validateScope?: () => Promise<void> | void;
       pendingSnapshot?: {
@@ -1050,9 +1068,23 @@ export class BotSkillSyncService {
     const stage = path.join(parent, `.bot-skills-stage-${operationID}`);
     const backup = path.join(parent, `.bot-skills-backup-${operationID}`);
     const packages: BotSkillPackage[] = [];
-    const previousManagedRoots = fs.existsSync(this.skillsRoot) && options.preserveUnmanaged !== false
-      ? scanBotSkillWorkspace(this.skillsRoot).map(entry => path.resolve(entry.path))
-      : [];
+    const workspaceExists = fs.existsSync(this.skillsRoot);
+    const preserveLocalOnlyWorkspace = options.preserveLocalOnlyWorkspace === true;
+    const preserveUnmanaged = options.preserveUnmanaged !== false || preserveLocalOnlyWorkspace;
+    /*
+     * Base is the only durable record of which workspace directories this Bot's
+     * Cloud Definition owns. The activation path must not fall back to "every
+     * Skill currently on disk is mine to replace": a first migration, a stale
+     * Base or an operator-attached server workspace would lose the Skills the
+     * owner never declared to Cloud. Without that record nothing is treated as
+     * replaceable, so the restore can only add Cloud Skills.
+     */
+    const previousBase = this.baseStore.read(this.botId);
+    const previousManagedRoots = !workspaceExists || !preserveUnmanaged
+      ? []
+      : preserveLocalOnlyWorkspace
+        ? cloudOwnedSkillRoots(this.skillsRoot, previousBase)
+        : scanBotSkillWorkspace(this.skillsRoot).map(entry => path.resolve(entry.path));
     const previousDefinition = this.definitionService.read(this.botId);
     let entries: BotSkillSyncBaseEntry[] = [];
     let localPendingEvidence: BotSkillSyncResult['localPendingEvidence'];
@@ -1062,7 +1094,7 @@ export class BotSkillSyncService {
     try {
       this.writeRestoreJournal({ stage, backup, phase: 'prepared' });
       const previousInstallNames = new Map(
-        (this.baseStore.read(this.botId)?.skills ?? []).map(entry => [
+        (previousBase?.skills ?? []).map(entry => [
           referenceKey(entry.reference),
           entry.installName,
         ]),
@@ -1097,14 +1129,15 @@ export class BotSkillSyncService {
       if (!botSkillRefsEqual(restoredRefs, cloud.skills)) {
         throw new Error('Restored Bot Skill workspace does not match its cloud Definition.');
       }
-      if (fs.existsSync(this.skillsRoot) && options.preserveUnmanaged !== false) {
+      if (workspaceExists && preserveUnmanaged) {
         copyUnmanagedWorkspaceContent(
           this.skillsRoot,
           stage,
           previousManagedRoots,
           stagedLocal.map(entry => path.resolve(entry.path)),
+          { skipConflicts: preserveLocalOnlyWorkspace },
         );
-        entries = verifiedRestoredEntries(stage, packages, cloud.skills);
+        entries = verifiedRestoredEntries(stagedLocal, packages, cloud.skills);
       }
 
       if (fs.existsSync(this.skillsRoot)) {
@@ -1494,12 +1527,40 @@ function referenceKey(reference: BotSkillRef): string {
   return `${reference.skillId}\0${reference.version}`;
 }
 
+/**
+ * Resolves the workspace directories Base attributes to this Bot's Cloud
+ * Definition. Only those paths may be replaced or removed by a Cloud restore:
+ * every other entry on disk belongs to the operator or the user.
+ */
+function cloudOwnedSkillRoots(
+  skillsRoot: string,
+  base: BotSkillSyncBase | undefined,
+): string[] {
+  const root = path.resolve(skillsRoot);
+  const owned = new Set<string>();
+  for (const entry of base?.skills ?? []) {
+    const installName = String(entry.installName || '').trim();
+    if (!installName || !isPortablePackagePath(installName)) continue;
+    const resolved = path.resolve(root, installName);
+    if (!isContainedPath(root, resolved)) continue;
+    owned.add(resolved);
+  }
+  return [...owned];
+}
+
+function isContainedPath(root: string, candidate: string): boolean {
+  const relative = path.relative(root, candidate);
+  return Boolean(relative) && !relative.startsWith('..') && !path.isAbsolute(relative);
+}
+
 function copyUnmanagedWorkspaceContent(
   sourceRoot: string,
   targetRoot: string,
   managedRoots: string[],
   targetManagedRoots: string[],
+  options: { skipConflicts?: boolean } = {},
 ): void {
+  const displaced: string[] = [];
   const visit = (current: string): void => {
     for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
       if (entry.isSymbolicLink()) continue;
@@ -1511,7 +1572,14 @@ function copyUnmanagedWorkspaceContent(
       if (targetManagedRoots.some(managed => (
         target === managed || target.startsWith(`${managed}${path.sep}`)
       ))) {
-        throw new Error(`Unmanaged workspace content conflicts with a restored Skill: ${relative}`);
+        if (!options.skipConflicts) {
+          throw new Error(`Unmanaged workspace content conflicts with a restored Skill: ${relative}`);
+        }
+        // Cloud owns this install path, so the restored Skill wins. The
+        // displaced entry stays recoverable in the snapshot the activation
+        // path takes before it replaces the workspace.
+        displaced.push(relative.replace(/\\/g, '/'));
+        continue;
       }
       if (entry.isDirectory()) {
         fs.mkdirSync(target, { recursive: true });
@@ -1523,27 +1591,45 @@ function copyUnmanagedWorkspaceContent(
     }
   };
   visit(sourceRoot);
+  if (displaced.length > 0) {
+    Logger.warning(
+      `Skill workspace restore preferred the Cloud Skill for ${displaced.length} local `
+      + `entr${displaced.length === 1 ? 'y' : 'ies'} sharing its install path: `
+      + `${displaced.slice(0, 5).join(', ')}${displaced.length > 5 ? ', ...' : ''}`,
+    );
+  }
 }
 
+/**
+ * Re-reads every Cloud package that was materialized into the stage after the
+ * workspace entries Cloud does not own were copied in. The copy only ever adds
+ * paths - it never overwrites a restored Skill - so this pass proves that each
+ * restored Skill is still intact and returns the Base entries for those Skills
+ * alone. Preserved local-only entries stay out of Base, which keeps them out of
+ * the Cloud definition instead of pretending Cloud owns them.
+ */
 function verifiedRestoredEntries(
-  stage: string,
+  stagedSkills: readonly LocalBotSkillManifestEntry[],
   packages: BotSkillPackage[],
   expectedRefs: BotSkillRef[],
 ): BotSkillSyncBaseEntry[] {
-  const finalLocal = scanBotSkillWorkspace(stage);
   const packageByLocalID = new Map(packages.map(item => [item.localSkillId, item]));
-  const entries = finalLocal.map(entry => {
-    const packageValue = packageByLocalID.get(entry.localSkillId);
-    if (!packageValue || packageValue.contentHash !== entry.contentHash || !entry.reference) {
-      throw new Error(`Restored Bot Skill failed post-copy verification: ${entry.name}`);
+  const entries = stagedSkills.map(staged => {
+    const packageValue = packageByLocalID.get(staged.localSkillId);
+    if (!packageValue) {
+      throw new Error(`Restored Bot Skill has no Cloud package: ${staged.name}`);
+    }
+    const current = scanLocalBotSkill(staged.path);
+    if (current.contentHash !== packageValue.contentHash || !current.reference) {
+      throw new Error(`Restored Bot Skill failed post-copy verification: ${staged.name}`);
     }
     return {
-      localSkillId: entry.localSkillId,
-      name: entry.name,
-      installName: entry.installName,
-      contentHash: entry.contentHash,
-      reference: entry.reference,
-      ...(entry.origin ? { origin: entry.origin } : {}),
+      localSkillId: current.localSkillId,
+      name: current.name,
+      installName: staged.installName,
+      contentHash: current.contentHash,
+      reference: current.reference,
+      ...(current.origin ? { origin: current.origin } : {}),
     };
   });
   const restoredRefs = canonicalizeBotSkillRefs(entries.map(entry => entry.reference));

--- a/src/bot-skills/sync-service.ts
+++ b/src/bot-skills/sync-service.ts
@@ -839,6 +839,11 @@ export class BotSkillSyncService {
    * dropping a Cloud-owned entry here would silently remove its reference from the
    * Definition and make every other device uninstall it. Without a Base there is
    * no way to prove the entry is local-only either, so both cases keep failing.
+   *
+   * Ownership is not a question of the install path alone. Base correlates its
+   * entries with local Skills by localSkillId, and a renamed Cloud-owned Skill
+   * keeps the marker id of its original install, so a moved directory still
+   * belongs to the Definition and both signals have to block the skip.
    */
   private readSyncableLocalManifest(
     base: BotSkillSyncBase | undefined,
@@ -848,10 +853,14 @@ export class BotSkillSyncService {
       onValidationFailure: failure => rejected.push(failure),
     });
     const cloudOwned = new Set(cloudOwnedSkillRoots(this.skillsRoot, base));
+    const cloudOwnedLocalIds = new Set(
+      (base?.skills ?? []).map(entry => entry.localSkillId),
+    );
     const blocking = rejected.find(failure => (
       failure.error.kind !== 'package-limit'
       || !base
       || cloudOwned.has(path.resolve(failure.path))
+      || cloudOwnedLocalIds.has(failure.localSkillId)
     ));
     if (blocking) throw blocking.error;
     reportSkippedLocalSkills(rejected);

--- a/src/bot-skills/sync-service.ts
+++ b/src/bot-skills/sync-service.ts
@@ -225,7 +225,7 @@ export class BotSkillSyncService {
       this.skillsRoot,
     );
     const base = this.baseStore.read(this.botId);
-    let local = this.readLocalManifest();
+    let local = this.readSyncableLocalManifest();
     let cloud: CloudBotSkills | undefined;
     try {
       cloud = await pullCloudBotSkills(this.cloudOptions);
@@ -239,7 +239,7 @@ export class BotSkillSyncService {
     }
 
     this.recoverInterruptedFinalizes(cloud);
-    local = this.readLocalManifest();
+    local = this.readSyncableLocalManifest();
 
     if (!cloud.definition) {
       if (!this.workspaceExisted && base?.skills.length) {
@@ -341,6 +341,11 @@ export class BotSkillSyncService {
    * written back to Cloud. Workspace entries the Definition does not own -
    * operator managed and user authored Skills, plus stray files such as notes -
    * are carried into the restored workspace instead of being deleted.
+   *
+   * Activation itself writes nothing to Cloud, but a carried entry stays an
+   * ordinary local Skill: a later routine sync() or an explicit owner publish
+   * can still turn it into a Bot private package. Only the delete-on-activate
+   * behaviour changes here, not the established Local to Cloud sync direction.
    */
   async reconcileActivationFromCloudOnly(): Promise<BotSkillSyncResult> {
     try {
@@ -818,6 +823,26 @@ export class BotSkillSyncService {
     };
   }
 
+  /**
+   * Routine sync reads the workspace through this helper. A single Skill the
+   * package validator rejects for its packaged size - too many files, or a file
+   * past the size limit - must not wedge every later sync: the entry is reported
+   * and skipped so the remaining Skills, the Base record and the Cloud Definition
+   * still converge. A skipped entry is never treated as Cloud owned, so a restore
+   * keeps it on disk. Broken content still fails loudly, and the owner-facing
+   * publish paths keep the strict read, because that owner asked to publish this
+   * workspace and needs to see the validation error.
+   */
+  private readSyncableLocalManifest(): LocalBotSkillManifestEntry[] {
+    const rejected: BotSkillWorkspaceValidationFailure[] = [];
+    const entries = this.readLocalManifest({
+      onValidationFailure: failure => rejected.push(failure),
+    });
+    assertOnlyPackageLimitsSkipped(rejected);
+    reportSkippedLocalSkills(rejected);
+    return entries;
+  }
+
   private async pushLocal(
     local: LocalBotSkillManifestEntry[],
     initialCloud: CloudBotSkills,
@@ -1084,7 +1109,7 @@ export class BotSkillSyncService {
       ? []
       : preserveLocalOnlyWorkspace
         ? cloudOwnedSkillRoots(this.skillsRoot, previousBase)
-        : scanBotSkillWorkspace(this.skillsRoot).map(entry => path.resolve(entry.path));
+        : scanManageableWorkspaceRoots(this.skillsRoot);
     const previousDefinition = this.definitionService.read(this.botId);
     let entries: BotSkillSyncBaseEntry[] = [];
     let localPendingEvidence: BotSkillSyncResult['localPendingEvidence'];
@@ -1528,6 +1553,44 @@ function referenceKey(reference: BotSkillRef): string {
 }
 
 /**
+ * Scans the workspace for the restore fallback, tolerating Skills the package
+ * validator rejects. An unreadable entry cannot be attributed to Cloud, so it is
+ * copied through the restore instead of being dropped, and one oversized Skill
+ * can no longer fail the whole restore. It is reported so the operator sees it.
+ */
+function scanManageableWorkspaceRoots(skillsRoot: string): string[] {
+  const rejected: BotSkillWorkspaceValidationFailure[] = [];
+  const roots = scanBotSkillWorkspace(skillsRoot, {
+    onValidationFailure: failure => rejected.push(failure),
+  }).map(entry => path.resolve(entry.path));
+  assertOnlyPackageLimitsSkipped(rejected);
+  reportSkippedLocalSkills(rejected);
+  return roots;
+}
+
+/**
+ * Skipping is only ever allowed for the packaged size limits. A Skill whose
+ * frontmatter, paths or contents are broken must keep failing the caller with
+ * the original validation error.
+ */
+function assertOnlyPackageLimitsSkipped(
+  rejected: BotSkillWorkspaceValidationFailure[],
+): void {
+  const blocking = rejected.find(failure => failure.error.kind !== 'package-limit');
+  if (blocking) throw blocking.error;
+}
+
+function reportSkippedLocalSkills(skipped: BotSkillWorkspaceValidationFailure[]): void {
+  if (skipped.length === 0) return;
+  Logger.warning(
+    `Skipped ${skipped.length} local Skill${skipped.length === 1 ? '' : 's'} that cannot be `
+    + 'packaged for synchronization; they stay on disk and are not uploaded: '
+    + `${skipped.slice(0, 5).map(entry => entry.installName).join(', ')}`
+    + `${skipped.length > 5 ? ', ...' : ''}`,
+  );
+}
+
+/**
  * Resolves the workspace directories Base attributes to this Bot's Cloud
  * Definition. Only those paths may be replaced or removed by a Cloud restore:
  * every other entry on disk belongs to the operator or the user.
@@ -1605,8 +1668,10 @@ function copyUnmanagedWorkspaceContent(
  * workspace entries Cloud does not own were copied in. The copy only ever adds
  * paths - it never overwrites a restored Skill - so this pass proves that each
  * restored Skill is still intact and returns the Base entries for those Skills
- * alone. Preserved local-only entries stay out of Base, which keeps them out of
- * the Cloud definition instead of pretending Cloud owns them.
+ * alone. Preserved local-only entries stay out of Base because this restore must
+ * not claim Cloud owns them - not because they are exempt from synchronization.
+ * They stay ordinary local Skills, so the next routine sync() may still publish
+ * them, and Base only records them once that publish actually happened.
  */
 function verifiedRestoredEntries(
   stagedSkills: readonly LocalBotSkillManifestEntry[],

--- a/tests/bot-skills-sync.test.ts
+++ b/tests/bot-skills-sync.test.ts
@@ -2019,6 +2019,11 @@ describe('Bot Skill Local/Base/Cloud sync', () => {
       ),
       ['cloud-a'],
     );
+    // The oversized operator Skill is not in Base, so it is provably not
+    // Cloud-owned and the next routine sync keeps converging without it.
+    const converged = await fixture.sync();
+    assert.equal(converged.direction, 'none');
+    assert.equal(fixture.patches, 0);
   });
 
   test('preserved operator Skills take part in the next routine sync', async () => {
@@ -2099,6 +2104,60 @@ describe('Bot Skill Local/Base/Cloud sync', () => {
       fs.readFileSync(path.join(operatorRoot, 'assets', 'file-259.txt'), 'utf8'),
       'asset 259',
     );
+  });
+
+  test('a Cloud-owned Skill too large to package fails the sync instead of deleting its Cloud reference', async () => {
+    const fixture = createFixture(roots);
+    writeSkill(fixture.skillsRoot, 'cloud-owned', 'cloud-owned', 'approved cloud owned');
+    await fixture.sync();
+    const ownedRoot = path.join(fixture.skillsRoot, 'cloud-owned');
+    const publishedReference = fixture.cloud.skills[0];
+    assert.ok(publishedReference);
+
+    // The same Cloud-owned install path, bloated past the package limits locally.
+    writeOversizedSkill(fixture.skillsRoot, 'cloud-owned');
+    fixture.uploads = 0;
+    fixture.patches = 0;
+
+    // A skipped entry disappears from the local manifest, and pushLocal builds the
+    // next BotDefinition from that manifest. Dropping a Cloud-owned entry that way
+    // would rewrite the Definition without its reference, so every other device
+    // would uninstall its copy. Keep failing loudly instead.
+    await assert.rejects(fixture.sync(), /too many files/i);
+
+    assert.equal(fixture.patches, 0);
+    assert.deepStrictEqual(fixture.cloud.skills, [publishedReference]);
+    assert.deepStrictEqual(
+      new BotSkillBaseStore(fixture.runtimeRoot).read(fixture.botId)?.skills.map(
+        entry => entry.name,
+      ),
+      ['cloud-owned'],
+    );
+    assert.equal(
+      fs.readFileSync(path.join(ownedRoot, 'assets', 'file-259.txt'), 'utf8'),
+      'asset 259',
+    );
+  });
+
+  test('activation replaces a Cloud-owned Skill that is too large to package locally', async () => {
+    const fixture = createFixture(roots);
+    writeSkill(fixture.skillsRoot, 'cloud-owned', 'cloud-owned', 'approved cloud owned');
+    await fixture.sync();
+
+    writeOversizedSkill(fixture.skillsRoot, 'cloud-owned');
+
+    // Routine sync() fails loudly for a Cloud-owned entry, so activation stays the
+    // recovery path: Cloud is authoritative for the install paths its Base record
+    // owns, and the local copy is snapshotted before it is replaced.
+    const activation = await fixture.activate();
+
+    assert.equal(activation.direction, 'cloud_to_local');
+    assert.match(
+      fs.readFileSync(path.join(fixture.skillsRoot, 'cloud-owned', 'SKILL.md'), 'utf8'),
+      /approved cloud owned/,
+    );
+    assert.equal(fs.existsSync(path.join(fixture.skillsRoot, 'cloud-owned', 'assets')), false);
+    assert.equal((await fixture.sync()).direction, 'none');
   });
 
   test('activation keeps a no-Base local workspace when the Cloud Definition is empty', async () => {

--- a/tests/bot-skills-sync.test.ts
+++ b/tests/bot-skills-sync.test.ts
@@ -2003,6 +2003,10 @@ describe('Bot Skill Local/Base/Cloud sync', () => {
     fixture.packages.set(refKey(cloudPackage.reference), cloudPackage);
     fixture.cloud = { revision: 1, skills: [definitionRef(cloudPackage)] };
 
+    // With no Base nothing proves the oversized entry is local-only, so the
+    // routine sync keeps failing loudly instead of risking the Cloud Definition.
+    await assert.rejects(fixture.sync(), /too many files/i);
+
     await fixture.activate();
 
     assert.match(
@@ -2136,6 +2140,77 @@ describe('Bot Skill Local/Base/Cloud sync', () => {
     assert.equal(
       fs.readFileSync(path.join(ownedRoot, 'assets', 'file-259.txt'), 'utf8'),
       'asset 259',
+    );
+  });
+
+  test('a renamed Cloud-owned Skill too large to package still blocks the routine sync', async () => {
+    const fixture = createFixture(roots);
+    writeSkill(fixture.skillsRoot, 'cloud-owned', 'cloud-owned', 'approved cloud owned');
+    await fixture.sync();
+    const publishedReference = fixture.cloud.skills[0];
+    assert.ok(publishedReference);
+
+    // The operator renames the install directory. Base correlates entries with
+    // local Skills by localSkillId, and the renamed copy still carries the marker
+    // of its original install, so it is the same Cloud-owned Skill even though
+    // its install path no longer matches Base.
+    fs.renameSync(
+      path.join(fixture.skillsRoot, 'cloud-owned'),
+      path.join(fixture.skillsRoot, 'renamed-cloud'),
+    );
+    writeOversizedSkill(fixture.skillsRoot, 'renamed-cloud');
+    fixture.uploads = 0;
+    fixture.patches = 0;
+
+    // Ownership by install path alone would call this entry local-only, skip it
+    // and rewrite the Definition without the reference, uninstalling the Skill on
+    // every other device. Keep failing loudly instead.
+    await assert.rejects(fixture.sync(), /too many files/i);
+
+    assert.equal(fixture.patches, 0);
+    assert.deepStrictEqual(fixture.cloud.skills, [publishedReference]);
+    assert.deepStrictEqual(
+      new BotSkillBaseStore(fixture.runtimeRoot).read(fixture.botId)?.skills.map(
+        entry => entry.installName,
+      ),
+      ['cloud-owned'],
+    );
+    assert.equal(
+      fs.readFileSync(
+        path.join(fixture.skillsRoot, 'renamed-cloud', 'assets', 'file-259.txt'),
+        'utf8',
+      ),
+      'asset 259',
+    );
+  });
+
+  test('a renamed Cloud-owned Skill stays bound to its Cloud reference', async () => {
+    const fixture = createFixture(roots);
+    writeSkill(fixture.skillsRoot, 'cloud-owned', 'cloud-owned', 'approved cloud owned');
+    await fixture.sync();
+    const publishedReference = fixture.cloud.skills[0];
+    assert.ok(publishedReference);
+
+    fs.renameSync(
+      path.join(fixture.skillsRoot, 'cloud-owned'),
+      path.join(fixture.skillsRoot, 'renamed-cloud'),
+    );
+
+    // Renaming alone is an ordinary Base follow-up: the entry keeps its
+    // localSkillId, so the Cloud reference is preserved and only the install
+    // name moves.
+    await fixture.sync();
+
+    assert.deepStrictEqual(fixture.cloud.skills, [publishedReference]);
+    assert.deepStrictEqual(
+      new BotSkillBaseStore(fixture.runtimeRoot).read(fixture.botId)?.skills.map(
+        entry => entry.installName,
+      ),
+      ['renamed-cloud'],
+    );
+    assert.match(
+      fs.readFileSync(path.join(fixture.skillsRoot, 'renamed-cloud', 'SKILL.md'), 'utf8'),
+      /approved cloud owned/,
     );
   });
 

--- a/tests/bot-skills-sync.test.ts
+++ b/tests/bot-skills-sync.test.ts
@@ -1998,15 +1998,7 @@ describe('Bot Skill Local/Base/Cloud sync', () => {
 
   test('activation restores Cloud around an operator Skill too large to package', async () => {
     const fixture = createFixture(roots);
-    const operatorRoot = path.join(fixture.skillsRoot, 'big-operator-skill');
-    fs.mkdirSync(path.join(operatorRoot, 'assets'), { recursive: true });
-    fs.writeFileSync(
-      path.join(operatorRoot, 'SKILL.md'),
-      skillText('big-operator-skill', 'too many files to package'),
-    );
-    for (let index = 0; index < 260; index += 1) {
-      fs.writeFileSync(path.join(operatorRoot, 'assets', `file-${index}.txt`), `asset ${index}`);
-    }
+    const operatorRoot = writeOversizedSkill(fixture.skillsRoot, 'big-operator-skill');
     const cloudPackage = createPackage(roots, 'cloud-a', 'cloud-a', 'canonical cloud');
     fixture.packages.set(refKey(cloudPackage.reference), cloudPackage);
     fixture.cloud = { revision: 1, skills: [definitionRef(cloudPackage)] };
@@ -2026,6 +2018,86 @@ describe('Bot Skill Local/Base/Cloud sync', () => {
         entry => entry.name,
       ),
       ['cloud-a'],
+    );
+  });
+
+  test('preserved operator Skills take part in the next routine sync', async () => {
+    const fixture = createFixture(roots);
+    writeSkill(fixture.skillsRoot, 'managed', 'managed', 'approved managed');
+    await fixture.sync();
+    writeSkill(fixture.skillsRoot, 'operator-a', 'operator-a', 'operator managed a');
+    const cloudPackage = createPackage(roots, 'managed', 'managed', 'owner approved cloud');
+    fixture.packages.set(refKey(cloudPackage.reference), cloudPackage);
+    fixture.cloud = { revision: 2, skills: [definitionRef(cloudPackage)] };
+    fixture.uploads = 0;
+    fixture.patches = 0;
+
+    const activation = await fixture.activate();
+    assert.equal(activation.direction, 'cloud_to_local');
+    assert.equal(fixture.uploads, 0);
+
+    // Activation only stops the delete. The carried entry stays an ordinary
+    // local Skill, so the established Local -> Cloud direction still applies.
+    const published = await fixture.sync();
+
+    assert.equal(published.direction, 'local_to_cloud');
+    assert.equal(fixture.uploads, 1);
+    assert.deepStrictEqual(
+      new BotSkillBaseStore(fixture.runtimeRoot).read(fixture.botId)?.skills.map(
+        entry => entry.name,
+      ).sort(),
+      ['managed', 'operator-a'],
+    );
+  });
+
+  test('a local Skill too large to package does not block the next routine sync', async () => {
+    const fixture = createFixture(roots);
+    writeSkill(fixture.skillsRoot, 'managed', 'managed', 'approved managed');
+    await fixture.sync();
+    const operatorRoot = writeOversizedSkill(fixture.skillsRoot, 'big-operator-skill');
+    const cloudPackage = createPackage(roots, 'managed', 'managed', 'owner approved cloud');
+    fixture.packages.set(refKey(cloudPackage.reference), cloudPackage);
+    fixture.cloud = { revision: 2, skills: [definitionRef(cloudPackage)] };
+    fixture.uploads = 0;
+    fixture.patches = 0;
+
+    await fixture.activate();
+
+    // The rejected entry is skipped instead of failing the whole sync, so the
+    // workspace, Base and the Cloud Definition still converge.
+    const converged = await fixture.sync();
+
+    assert.equal(converged.direction, 'none');
+    assert.equal(fixture.uploads, 0);
+    assert.equal(
+      fs.readFileSync(path.join(operatorRoot, 'assets', 'file-259.txt'), 'utf8'),
+      'asset 259',
+    );
+  });
+
+  test('a local Skill too large to package survives a Cloud restore', async () => {
+    const fixture = createFixture(roots);
+    writeSkill(fixture.skillsRoot, 'managed', 'managed', 'approved managed');
+    await fixture.sync();
+    const operatorRoot = writeOversizedSkill(fixture.skillsRoot, 'big-operator-skill');
+    const cloudPackage = createPackage(roots, 'cloud-b', 'cloud-b', 'cloud only');
+    fixture.packages.set(refKey(cloudPackage.reference), cloudPackage);
+    fixture.cloud = {
+      revision: fixture.cloud.revision + 1,
+      skills: [definitionRef(cloudPackage)],
+    };
+
+    const restored = await fixture.sync();
+
+    assert.equal(restored.direction, 'cloud_to_local');
+    assert.match(
+      fs.readFileSync(path.join(fixture.skillsRoot, 'cloud-b', 'SKILL.md'), 'utf8'),
+      /cloud only/,
+    );
+    assert.equal(fs.existsSync(path.join(fixture.skillsRoot, 'managed')), false);
+    assert.equal(
+      fs.readFileSync(path.join(operatorRoot, 'assets', 'file-259.txt'), 'utf8'),
+      'asset 259',
     );
   });
 
@@ -2715,6 +2787,20 @@ function writeSkill(root: string, directory: string, name: string, body: string)
 
 function skillText(name: string, body: string): string {
   return `---\nname: ${name}\ndescription: test\n---\n\n${body}\n`;
+}
+
+/** Writes an operator Skill past MAX_FILES so the package validator rejects it. */
+function writeOversizedSkill(root: string, directory: string): string {
+  const skillRoot = path.join(root, directory);
+  fs.mkdirSync(path.join(skillRoot, 'assets'), { recursive: true });
+  fs.writeFileSync(
+    path.join(skillRoot, 'SKILL.md'),
+    skillText(directory, 'too many files to package'),
+  );
+  for (let index = 0; index < 260; index += 1) {
+    fs.writeFileSync(path.join(skillRoot, 'assets', `file-${index}.txt`), `asset ${index}`);
+  }
+  return skillRoot;
 }
 
 function createPackage(

--- a/tests/bot-skills-sync.test.ts
+++ b/tests/bot-skills-sync.test.ts
@@ -1887,7 +1887,7 @@ describe('Bot Skill Local/Base/Cloud sync', () => {
     );
   });
 
-  test('activation preserves a no-Base legacy workspace before materializing Cloud', async () => {
+  test('activation keeps a no-Base legacy workspace while materializing Cloud', async () => {
     const fixture = createFixture(roots);
     writeSkill(fixture.skillsRoot, 'legacy', 'legacy', 'legacy local only');
     const cloudPackage = createPackage(roots, 'cloud-a', 'cloud-a', 'canonical cloud');
@@ -1898,14 +1898,135 @@ describe('Bot Skill Local/Base/Cloud sync', () => {
 
     assert.equal(fixture.uploads, 0);
     assert.equal(fixture.patches, 0);
-    assert.equal(fs.existsSync(path.join(fixture.skillsRoot, 'legacy')), false);
+    assert.match(
+      fs.readFileSync(path.join(fixture.skillsRoot, 'legacy', 'SKILL.md'), 'utf8'),
+      /legacy local only/,
+    );
     assert.match(
       fs.readFileSync(path.join(fixture.skillsRoot, 'cloud-a', 'SKILL.md'), 'utf8'),
       /canonical cloud/,
     );
+    assert.deepStrictEqual(
+      new BotSkillBaseStore(fixture.runtimeRoot).read(fixture.botId)?.skills.map(
+        entry => entry.name,
+      ),
+      ['cloud-a'],
+    );
     const snapshot = readPendingSnapshot(fixture.runtimeRoot, fixture.botId);
     assert.equal(snapshot.manifest.reason, 'activation_without_base');
     assert.equal(snapshot.manifest.baseRevision, undefined);
+  });
+
+  test('activation keeps operator-managed local Skills next to Cloud Skills', async () => {
+    const fixture = createFixture(roots);
+    writeSkill(fixture.skillsRoot, 'managed', 'managed', 'approved managed');
+    await fixture.sync();
+    writeSkill(fixture.skillsRoot, 'operator-a', 'operator-a', 'operator managed a');
+    writeSkill(fixture.skillsRoot, 'operator-b', 'operator-b', 'operator managed b');
+    const cloudPackage = createPackage(roots, 'managed', 'managed', 'owner approved cloud');
+    fixture.packages.set(refKey(cloudPackage.reference), cloudPackage);
+    fixture.cloud = { revision: 2, skills: [definitionRef(cloudPackage)] };
+    fixture.uploads = 0;
+    fixture.patches = 0;
+
+    const result = await fixture.activate();
+
+    assert.equal(result.direction, 'cloud_to_local');
+    assert.equal(fixture.uploads, 0);
+    assert.equal(fixture.patches, 0);
+    assert.match(
+      fs.readFileSync(path.join(fixture.skillsRoot, 'managed', 'SKILL.md'), 'utf8'),
+      /owner approved cloud/,
+    );
+    assert.match(
+      fs.readFileSync(path.join(fixture.skillsRoot, 'operator-a', 'SKILL.md'), 'utf8'),
+      /operator managed a/,
+    );
+    assert.match(
+      fs.readFileSync(path.join(fixture.skillsRoot, 'operator-b', 'SKILL.md'), 'utf8'),
+      /operator managed b/,
+    );
+    assert.deepStrictEqual(
+      new BotSkillBaseStore(fixture.runtimeRoot).read(fixture.botId)?.skills.map(
+        entry => entry.name,
+      ),
+      ['managed'],
+    );
+    assert.deepStrictEqual(
+      fixture.definitionService.read(fixture.botId)?.skills,
+      [definitionRef(cloudPackage)],
+    );
+  });
+
+  test('activation prefers the Cloud Skill over a local entry on the same install path', async () => {
+    const fixture = createFixture(roots);
+    writeSkill(
+      fixture.skillsRoot,
+      'image-asset-generator',
+      'image-asset-generator',
+      'operator local copy',
+    );
+    const cloudPackage = createPackage(
+      roots,
+      'image-asset-generator',
+      'image-asset-generator',
+      'canonical cloud copy',
+    );
+    fixture.packages.set(refKey(cloudPackage.reference), cloudPackage);
+    fixture.cloud = { revision: 1, skills: [definitionRef(cloudPackage)] };
+
+    const result = await fixture.activate();
+
+    assert.equal(result.direction, 'cloud_to_local');
+    assert.equal(fixture.uploads, 0);
+    assert.match(
+      fs.readFileSync(
+        path.join(fixture.skillsRoot, 'image-asset-generator', 'SKILL.md'),
+        'utf8',
+      ),
+      /canonical cloud copy/,
+    );
+    const snapshot = readPendingSnapshot(fixture.runtimeRoot, fixture.botId);
+    assert.match(
+      fs.readFileSync(
+        path.join(snapshot.path, 'package', 'image-asset-generator', 'SKILL.md'),
+        'utf8',
+      ),
+      /operator local copy/,
+    );
+  });
+
+  test('activation restores Cloud around an operator Skill too large to package', async () => {
+    const fixture = createFixture(roots);
+    const operatorRoot = path.join(fixture.skillsRoot, 'big-operator-skill');
+    fs.mkdirSync(path.join(operatorRoot, 'assets'), { recursive: true });
+    fs.writeFileSync(
+      path.join(operatorRoot, 'SKILL.md'),
+      skillText('big-operator-skill', 'too many files to package'),
+    );
+    for (let index = 0; index < 260; index += 1) {
+      fs.writeFileSync(path.join(operatorRoot, 'assets', `file-${index}.txt`), `asset ${index}`);
+    }
+    const cloudPackage = createPackage(roots, 'cloud-a', 'cloud-a', 'canonical cloud');
+    fixture.packages.set(refKey(cloudPackage.reference), cloudPackage);
+    fixture.cloud = { revision: 1, skills: [definitionRef(cloudPackage)] };
+
+    await fixture.activate();
+
+    assert.match(
+      fs.readFileSync(path.join(fixture.skillsRoot, 'cloud-a', 'SKILL.md'), 'utf8'),
+      /canonical cloud/,
+    );
+    assert.equal(
+      fs.readFileSync(path.join(operatorRoot, 'assets', 'file-259.txt'), 'utf8'),
+      'asset 259',
+    );
+    assert.deepStrictEqual(
+      new BotSkillBaseStore(fixture.runtimeRoot).read(fixture.botId)?.skills.map(
+        entry => entry.name,
+      ),
+      ['cloud-a'],
+    );
   });
 
   test('activation keeps a no-Base local workspace when the Cloud Definition is empty', async () => {
@@ -2151,7 +2272,7 @@ describe('Bot Skill Local/Base/Cloud sync', () => {
     );
   });
 
-  test('activation snapshots unscanned workspace files before a Cloud change removes them', async () => {
+  test('activation carries unscanned workspace files through a Cloud change', async () => {
     const fixture = createFixture(roots);
     writeSkill(fixture.skillsRoot, 'local-a', 'local-a', 'approved local');
     await fixture.sync();
@@ -2164,7 +2285,20 @@ describe('Bot Skill Local/Base/Cloud sync', () => {
 
     await fixture.activate();
 
-    assert.equal(fs.existsSync(path.join(fixture.skillsRoot, 'README.md')), false);
+    assert.equal(
+      fs.readFileSync(path.join(fixture.skillsRoot, 'README.md'), 'utf8'),
+      'local operator notes',
+    );
+    assert.equal(
+      fs.readFileSync(path.join(fixture.skillsRoot, '.drafts', 'idea.md'), 'utf8'),
+      'recoverable draft',
+    );
+    // Base-owned Skills stay replaceable, so the removed Cloud Skill is gone.
+    assert.equal(fs.existsSync(path.join(fixture.skillsRoot, 'local-a')), false);
+    assert.match(
+      fs.readFileSync(path.join(fixture.skillsRoot, 'cloud-b', 'SKILL.md'), 'utf8'),
+      /canonical cloud/,
+    );
     const snapshot = readPendingSnapshot(fixture.runtimeRoot, fixture.botId);
     assert.equal(snapshot.manifest.reason, 'activation_cloud_reconcile');
     assert.equal(


### PR DESCRIPTION
## 背景 / Background

Bot 激活时（`reconcileActivationFromCloudOnly`）把 Cloud BotDefinition 当成唯一权威，用 `restoreCloud(cloud, { preserveUnmanaged: false })` 整体替换工作区，于是 **Definition 没有声明的 Skill 会被直接删掉**。guga 那次事故就是这样丢了 16 个运维/自建 Skill。

直接把 `preserveUnmanaged` 打开也不行：没有可用的 Base 记录时，整个工作区都会被扫描成 “managed”，本地独有的 Skill 依然被跳过并删除；`verifiedRestoredEntries` 会扫描整个 stage，只要多出任何本地 Skill 就抛错；同名 install 路径冲突（guga 的本地 `image-asset-generator` 对云端两条）也会直接抛错。

During activation the Cloud Definition was treated as the sole authority and the workspace was replaced with `preserveUnmanaged: false`, so every Skill the Definition did not declare was deleted. Turning `preserveUnmanaged` on was not enough either: with no usable Base record the whole workspace scanned as managed, post-copy verification rejected any extra entry, and same-install-path collisions threw.

## 改动 / Change

### 1. 激活不再删除 Cloud 不拥有的 Skill（`18a541f`）

Cloud 只对 **它自己 Base 记录里声明的 Skill** 拥有权威性，其余一律保留：

- `restoreCloud` / `restoreCloudUnchecked` 新增 `preserveLocalOnlyWorkspace`，由激活路径设置。
- 新增 `cloudOwnedSkillRoots()`：可替换路径 **只** 来自 Base 的 `installName`（并做 `isPortablePackagePath` + 目录包含校验）。Base 缺失 → 没有任何可替换目录 → 这次 restore 只能新增 Cloud Skill，不会删任何东西。
- 同名 install 路径冲突：Cloud 优先，被顶掉的本地目录不再抛错，改为汇总一条 `Logger.warning`，且仍可从 pending 快照里找回。
- 校验改为 **只针对 Cloud 包** 逐个 `scanLocalBotSkill` 重新读回，允许 stage 中存在额外的本地独有 Skill。
- Base 与 BotDefinition 在这次 restore 中 **只记录 Cloud 拥有的 Skill**，不伪造所有权。

### 2. 被保留的 Skill 不再让后续同步卡死，且不会静默改写 Definition（`b926d82` + `f4f4cd9`）

激活只是“当次不删”，被保留的条目仍然是普通的本地 Skill，会继续走既有的 Local → Cloud 同步方向（这也是本地 Skill 出现在 SkillHub 的既有机制）。但原来的例行 `sync()` 有两个假设会因此卡死：

- `readLocalManifest` 没传 `onValidationFailure`，所以一个超过打包上限的本地 Skill（> `MAX_FILES` 个文件，或单文件过大）会让 **之后每一次** `sync()` 都 reject，Cloud Definition 永远不再收敛；
- restore 的兜底扫描是严格模式，同一个超限 Skill 会让 Cloud restore 整体失败。

现在：

- 例行同步走 `readSyncableLocalManifest(base)`，restore 兜底走 `scanManageableWorkspaceRoots()`，超限条目被报告（`Logger.warning` 列出名字）后跳过，其余 Skill、Base、Cloud Definition 继续收敛；
- **跳过只作用于「不可能属于 Cloud」的条目**（审阅第三轮 `f4f4cd9`、第四轮 `4a8cf75`）。被跳过的条目会从本地清单里消失，而 `pushLocal` 构建的下一份 BotDefinition 正是由这份清单来的：如果跳过的是 Cloud 拥有的条目，Definition 里那条 reference 会被静默删掉，其它设备下次激活就会删掉自己的副本（比原来的「一直报错」更难发现）。所以 ownership 用两个信号一起判定，任一命中就保持原来的大声失败（不上传、不改 Definition、不动本地文件）：
  - 超限条目的 install 路径在 `cloudOwnedSkillRoots(Base)` 里；
  - **或** 它的 `localSkillId` 命中 Base 里的条目。`pushLocal` 本来就是按 `localSkillId` 与 Base 关联的；目录被本地改名后 marker 里的 id 不变、只有 install 路径变了，所以「本地改名后的 Cloud Skill」仍然是同一个 Skill，只按路径判定会把它误认成本地独有；
  - 连 Base 都没有 → 无法证明它属于本地，同样保持失败；
  - 只有能证明不被 Base 拥有的超限条目才跳过；
- **跳过只限打包体积上限**：`BotSkillPackageValidationError` 新增 `kind: 'content' | 'package-limit'`，其它失败原样抛出，所以 SKILL.md frontmatter 非法、路径不安全、内容敏感等仍然照旧大声失败；owner 主动发布（`pushWorkspaceToCloud` / finalize）依旧走严格读取。
- restore 兜底不需要同一套 ownership 收窄：被拒绝的条目本来就落在 managed 集合之外，`copyUnmanagedWorkspaceContent` 不会让它覆盖 Cloud 还原出来的 Skill（是响亮的冲突报错，不是静默删除）。已在该函数注释里写明。

## 现有能力影响 / Risk to existing behaviour

- 只有激活路径传 `preserveLocalOnlyWorkspace`。其他 `restoreCloud(cloud)` 调用（`preserveUnmanaged` 未设置）走的表达式、复制逻辑、冲突抛错行为与改动前一致。
- 严格激活语义保留：Base 拥有的 Cloud Skill 依然被替换/删除，Cloud 仍是它们的权威。
- 例行的 Local → Cloud 同步方向没有改变：本次只让「可证明不被 Cloud 拥有 + 体积超限」的条目被跳过；**Cloud 拥有的超限条目仍然和改动前一样让 `sync()` 报错**（不静默改 Definition、不删本地文件、不上传），无论是原 install 路径还是被本地改名后的目录。运维侧的可恢复路径是把这个 Skill 修到可打包、或靠激活按 Cloud 重新还原该 install 路径（本地副本先落 pending 快照）。
- 无 Base 的工作区遇到超限条目同样是大声失败（与 `18a541f` 行为一致）：没有 Base 就无法判定它是否属于本地，宁可报错也不冒险改 Definition。
- 内容类校验（frontmatter、路径、敏感内容）依旧严格失败，有既有用例守护。

## 测试 / Tests

- `tests/bot-skills-sync.test.ts`：70/70 通过。本轮相关用例：
  - `activation keeps a no-Base legacy workspace while materializing Cloud`
  - `activation keeps operator-managed local Skills next to Cloud Skills`
  - `activation prefers the Cloud Skill over a local entry on the same install path`
  - `activation restores Cloud around an operator Skill too large to package`（并断言紧接着的例行 `sync()` 仍然 `direction: none`，即 guga 场景不再卡死）
  - `preserved operator Skills take part in the next routine sync`（把审阅提到的「下次 sync 会 push」写成显式断言）
  - `a local Skill too large to package does not block the next routine sync`
  - `a local Skill too large to package survives a Cloud restore`
  - `a Cloud-owned Skill too large to package fails the sync instead of deleting its Cloud reference`（审阅第三轮的复现，断言 `patches=0`、Definition reference 不变、Base 不变、本地文件还在）
  - `activation replaces a Cloud-owned Skill that is too large to package locally`（激活仍是 Cloud 拥有条目的恢复路径，之后 sync 收敛）
  - `a renamed Cloud-owned Skill too large to package still blocks the routine sync`（审阅第四轮的复现：Cloud Skill 目录被改名 + 加文件越限，断言 reject、`patches=0`、Definition/`cloud.skills`/Base 引用不变、本地文件仍在；该用例在 `f4f4cd9` 上会红于 `Missing expected rejection`）
  - `a renamed Cloud-owned Skill stays bound to its Cloud reference`（对照：只改名不加文件时原引用继续保留，Base 的 `installName` 更新为新目录）
- `bot-skill-preservation` / `bot-skill-workspace` / `bot-definition-skills` / `cloud-bot-model-apply-retry` / `bot-skills-activation-state` / `bot-skill-candidate-workspace` / `bot-skills-writer-lock`：72 tests / 71 通过 / 0 失败（1 个 symlink 用例在 Windows 跳过）。
- `npm run test:skillhub-phase1`：304 tests / 301 通过 / 0 失败（3 个 symlink 用例在 Windows 跳过）。
- `npm run build`（tsc）：通过。
- `npm test` 中的 `bundled-*-runtime.test.ts` 与 `update-worker-artifact.test.ts` 在本机失败；已用 `git stash` 在未改动的基线上复现同样结果，属于环境问题（缺 `jq`、bundled 资源布局），与本 PR 无关。

## 合并后运维收尾 / Follow-up after merge

guga（121.11.235.48）的 `/srv/catsco-agent/.env` 里有临时的 `XIAOBA_PRESERVE_SKILLS=1` 逃生舱，合并后应撤掉并重启 `catsco-agent.service`，再确认 24 个 Skill 完好、模型切换正常（看日志与实际对话模型，不能只看下拉框）。

需要产品决策的后续项（不在本 PR 内）：被保留的本地独有 Skill 是否应该 **不再** 被例行同步发布到 Cloud。当前 Base 条目必须带 Cloud reference，要做到「本地独有、不参与 push」需要改 Base 语义，影响面较大，建议单独评估。

