### PR TITLE
chore: bump desktop release to 1.5.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xiaoba-cli",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xiaoba-cli",
-      "version": "1.5.6",
+      "version": "1.5.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.27.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xiaoba-cli",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "description": "CatsCo - local agent runtime and dashboard",
   "main": "electron/main.js",
   "bin": {

--- a/scripts/prepare-runtime.mjs
+++ b/scripts/prepare-runtime.mjs
@@ -315,12 +315,25 @@ function extractArchive(archivePath, extractRoot, archiveType) {
   switch (archiveType) {
     case 'zip':
       if (process.platform === 'win32') {
-        runCommand('powershell.exe', [
+        // Some stripped Windows images do not ship the Microsoft.PowerShell.Archive
+        // module. Use the inbox tar implementation as a compatible fallback so
+        // packaging does not depend on an optional PowerShell module.
+        const probe = spawnSync('powershell.exe', [
           '-NoProfile',
           '-NonInteractive',
           '-Command',
-          `Expand-Archive -LiteralPath \"${escapePowerShellPath(archivePath)}\" -DestinationPath \"${escapePowerShellPath(extractRoot)}\" -Force`,
-        ]);
+          'Get-Command Expand-Archive -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Name',
+        ], { encoding: 'utf8', windowsHide: true });
+        if (probe.status === 0 && String(probe.stdout || '').trim() === 'Expand-Archive') {
+          runCommand('powershell.exe', [
+            '-NoProfile',
+            '-NonInteractive',
+            '-Command',
+            `Expand-Archive -LiteralPath \"${escapePowerShellPath(archivePath)}\" -DestinationPath \"${escapePowerShellPath(extractRoot)}\" -Force`,
+          ]);
+        } else {
+          runCommand('tar', ['-xf', archivePath, '-C', extractRoot]);
+        }
       } else {
         runCommand('unzip', ['-q', archivePath, '-d', extractRoot]);
       }


### PR DESCRIPTION
Bump the desktop package to 1.5.7 after the body transfer and dynamic model registry fixes. Also fall back to inbox tar when Windows lacks Microsoft.PowerShell.Archive, keeping runtime preparation portable.