### PR TITLE
chore: retain three worker image and app versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -923,3 +923,59 @@ jobs:
 
           prune_bucket "$TOS_TARGET_BUCKET" "$TOS_TARGET_REGION" guangzhou
           prune_bucket "$TOS_SOURCE_BUCKET" "$TOS_SOURCE_REGION" hong-kong
+
+      - name: Prune old worker application releases
+        shell: bash
+        env:
+          AWS_ACCESS_KEY_ID: ${{ env.VOLC_TOS_WORKER_PUBLISH_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ env.VOLC_TOS_WORKER_PUBLISH_SECRET_ACCESS_KEY }}
+        run: |
+          set -euo pipefail
+
+          WORKER_ENDPOINT_URL="https://tos-s3-${TOS_WORKER_REGION}.volces.com"
+          RETENTION_DIR="$(mktemp -d)"
+          trap 'rm -rf "$RETENTION_DIR"' EXIT
+
+          aws s3api list-objects-v2 \
+            --bucket "$TOS_WORKER_BUCKET" \
+            --prefix update/worker/ \
+            --endpoint-url "$WORKER_ENDPOINT_URL" \
+            --output json > "$RETENTION_DIR/worker-before.json"
+
+          node scripts/plan-release-retention.mjs \
+            --listing "$RETENTION_DIR/worker-before.json" \
+            --keep-versions 3 \
+            --min-age-days 1 \
+            --max-delete-objects 40 \
+            > "$RETENTION_DIR/worker-plan.json"
+
+          jq '{policy, protectedVersions, deleteVersions, deferredVersions, totals}' \
+            "$RETENTION_DIR/worker-plan.json"
+          delete_count="$(jq -r '.totals.deleteObjects' "$RETENTION_DIR/worker-plan.json")"
+          if [ "$delete_count" -eq 0 ]; then
+            echo "No old worker application release objects are eligible for deletion"
+            exit 0
+          fi
+
+          jq '{Objects: [.deleteObjects[] | {Key: .key}], Quiet: false}' \
+            "$RETENTION_DIR/worker-plan.json" > "$RETENTION_DIR/worker-delete.json"
+          aws s3api delete-objects \
+            --bucket "$TOS_WORKER_BUCKET" \
+            --delete "file://$RETENTION_DIR/worker-delete.json" \
+            --endpoint-url "$WORKER_ENDPOINT_URL" \
+            --output json > "$RETENTION_DIR/worker-delete-result.json"
+          jq -e '(.Errors // []) | length == 0' "$RETENTION_DIR/worker-delete-result.json" >/dev/null
+
+          aws s3api list-objects-v2 \
+            --bucket "$TOS_WORKER_BUCKET" \
+            --prefix update/worker/ \
+            --endpoint-url "$WORKER_ENDPOINT_URL" \
+            --output json > "$RETENTION_DIR/worker-after.json"
+          jq -n -e \
+            --slurpfile plan "$RETENTION_DIR/worker-plan.json" \
+            --slurpfile after "$RETENTION_DIR/worker-after.json" '
+              ($plan[0].deleteObjects | map(.key)) as $deleted
+              | ($after[0].Contents // [] | map(.Key)) as $remaining
+              | [$deleted[] | select(. as $key | $remaining | index($key))] | length == 0
+            ' >/dev/null
+          echo "Deleted $delete_count old worker application objects; newest three versions were preserved"

--- a/.github/workflows/worker-image.yml
+++ b/.github/workflows/worker-image.yml
@@ -711,7 +711,7 @@ jobs:
             -SecurityGroupID $env:WORKER_SECURITY_GROUP_ID
 
       - name: Prune old worker images
-        # Keep the latest 6 worker images after a successful bake; cleaning up
+        # Keep the latest 3 worker images after a successful bake; cleaning up
         # old images is housekeeping, so a prune failure only warns and never
         # blocks the freshly baked image (the primary deliverable). 30 minutes
         # covers the worst case where many stale images accumulated (each
@@ -732,7 +732,7 @@ jobs:
         run: |
           ./ops/ctyun-worker-image/Manage-WorkerImages.ps1 `
             -Action Prune `
-            -Keep 6 `
+            -Keep 3 `
             -RegionID $env:WORKER_REGION_ID `
             -ProjectID $env:WORKER_IMAGE_PROJECT_ID `
             -ProtectedImageIDs $env:WORKER_PROTECTED_IMAGE_IDS

--- a/docs/superpowers/plans/2026-08-05-worker-image-platform-hardening.md
+++ b/docs/superpowers/plans/2026-08-05-worker-image-platform-hardening.md
@@ -40,7 +40,7 @@
 
 ## 后续改进项（Follow-ups，不阻塞合入）
 
-- **▶ 镜像生命周期 + 云端控制（下一步主方向）**：见 `2026-08-07-worker-cloud-control-image-lifecycle.md`——私有 `catsco-worker-*` 镜像保留 6 个、bake 后自动清理；控制面 web（「云托管」入口）统一云虚拟员工创建（带配额）/版本展示/镜像回滚/单 worker 重置；Part A 制品更新（有数据回滚）为后续项。
+- **▶ 镜像生命周期 + 云端控制（下一步主方向）**：见 `2026-08-07-worker-cloud-control-image-lifecycle.md`——私有 `catsco-worker-*` 镜像保留 3 个、bake 后自动清理；控制面 web（「云托管」入口）统一云虚拟员工创建（带配额）/版本展示/镜像回滚/单 worker 重置；Part A 制品更新（有数据回滚）为后续项。
 - **发现阶段 3 次空读无直接测试场景**：Remove-Builder/Remove-KeyPair 的连续空读发现逻辑只在确认阶段有测试覆盖；构造"builder ID 存在但查询为空"场景成本高，防御性逻辑，后续补。
 - **`/boot` 校验的 `NEWEST_KERNEL_IMG` 变量是死代码**：非空性已被前置 `ls -1 /boot/vmlinuz-*` 保证，可删除或改为与升级前内核版本做真实比较。
 - **`Invoke-ExactBakeCleanup` key pair 单次读**与 Remove-* 的 3 次空读不对称（最终一致性风险低，因 Cleanup 运行在中断后较久），后续可对齐。

--- a/docs/superpowers/plans/2026-08-07-worker-cloud-control-image-lifecycle.md
+++ b/docs/superpowers/plans/2026-08-07-worker-cloud-control-image-lifecycle.md
@@ -8,7 +8,7 @@
 - **本计划目标：** 把云虚拟员工（worker）的**创建 / 版本展示 / 回滚 / 重置**统一到**控制面 web（"云托管"入口）**，并完善**镜像生命周期**（保留 N 个、bake 后自动清理、部署/控制面取最新镜像）。
 - **用户当前思路（2026-08-07 确认）：**
   1. 控制面 web 界面放在「**云托管**」按钮这里（截图：AI 助手管理对话框的"自托管 / 云托管"选项，云托管 → 云虚拟员工管理），**所有云虚拟员工的界面配置控制集中在此**。
-  2. **私有镜像保留 6 个**（`catsco-worker-*`），**bake 成功后自动触发清理**旧镜像。
+  2. **私有镜像保留 3 个**（`catsco-worker-*`），**bake 成功后自动触发清理**旧镜像。
   3. 虚拟员工**显示版本**；有历史镜像可选时支持**镜像回滚**。
   4. web 按钮带「**可创建云虚拟员工次数**」配额——有剩余次数就能点按钮触发创建，后端跑脚本（复用现有 bake/供给流程）。**配额用环境变量控制**（谁能开、开几个），**初始值 0**。
   5. **重置**是**针对单个服务器上的那个虚拟员工**，用户一般**一个一个**重置（非批量）。
@@ -23,25 +23,25 @@
 
 ## 模块 A：镜像生命周期管理（XiaoBa-CLI 侧）
 
-**目标：** 私有 `catsco-worker-*` 镜像**最多保留 6 个**；bake 成功后自动清理更旧的；提供"取最新镜像"能力供部署/控制面使用；支持列出历史镜像供回滚选择。
+**目标：** 私有 `catsco-worker-*` 镜像**最多保留 3 个**；bake 成功后自动清理更旧的；提供"取最新镜像"能力供部署/控制面使用；支持列出历史镜像供回滚选择。
 
 ### A1. 镜像保留与自动清理
 - [x] **步骤 A1-1：清理逻辑设计**（2026-08-07）
   - 在 bake **成功后**自动触发清理（幂等，可独立调用）。
-  - 规则：列出私有镜像 `catsco-worker-*`（`ims ListImage --imageVisibilityCode 0`），按 `createdTime` 排序，**保留最新 6 个**，删除更旧的。
+  - 规则：列出私有镜像 `catsco-worker-*`（`ims ListImage --imageVisibilityCode 0`），按 `createdTime` 排序，**保留最新 3 个**，删除更旧的。
   - **安全（fail-closed）**：只删名称以 `catsco-worker-` 开头且带 `bake` label 的镜像；删除前连续空读确认（用 `ListImage` 全量过滤，不用 `GetImageDetail`——实测其对私有镜像偶发 NotFound）；删除失败聚合报告。
   - 触发：`worker-image.yml` bake 成功步骤后自动调用（`continue-on-error`，清理失败仅告警不阻塞镜像产出）。
 - [x] **步骤 A1-2：测试**（`tests/manage-worker-images.test.ts`）
-  - fake `ims ListImage/DeleteImage` 支持多镜像排序；场景：List 只列带 bake label 的 `catsco-worker-*`、Latest 输出最新、Prune 6 删最旧 2、≤6 不删、删除失败 fail-closed 且其它照常删、非 worker/无 bake label 镜像永不删。
+  - fake `ims ListImage/DeleteImage` 支持多镜像排序；场景：List 只列带 bake label 的 `catsco-worker-*`、Latest 输出最新、Prune 3 删最旧 2、≤3 不删、删除失败 fail-closed 且其它照常删、非 worker/无 bake label 镜像永不删。
 - [x] **步骤 A1-3：实现 + 验证**
-  - 新建 `ops/ctyun-worker-image/Manage-WorkerImages.ps1`（`-Action List/Latest/Prune -Keep 6`）；`worker-image.yml` bake 成功后接入 `Prune -Keep 6`；`npm run build` + 测试 12/12 全绿。
+  - 新建 `ops/ctyun-worker-image/Manage-WorkerImages.ps1`（`-Action List/Latest/Prune -Keep 3`）；`worker-image.yml` bake 成功后接入 `Prune -Keep 3`；`npm run build` + 测试 12/12 全绿。
 
 ### A2. 部署/控制面取最新镜像
 - [x] **步骤 A2-1：`resolve-latest-worker-image`**（`Manage-WorkerImages.ps1 -Action Latest`）
   - 列出 `catsco-worker-*` 私有镜像，按 `createdTime`（降序，id 兜底）取最新，输出 `imageID`。
   - 部署脚本 / 控制面（Part B）用它创建新 worker。
 - [x] **步骤 A2-2：历史镜像列表（供回滚选择）**（`Manage-WorkerImages.ps1 -Action List`）
-  - 输出 `imageID / name / version / commit / createdTime / status`，控制面据此展示"镜像回滚"可选列表（保留 6 个内的历史镜像）。
+  - 输出 `imageID / name / version / commit / createdTime / status`，控制面据此展示"镜像回滚"可选列表（保留 3 个内的历史镜像）。
 
 ---
 
@@ -77,7 +77,7 @@
 
 ## 关键决策（已确认 / 待确认）
 
-- ✅ 镜像保留 **6 个**；bake 成功后自动清理。
+- ✅ 镜像保留 **3 个**；bake 成功后自动清理。
 - ✅ 重置为**单 worker** 逐个操作（强确认）。
 - ✅ 控制面入口为「云托管」按钮，含创建配额。
 - ✅ **回滚与重置两个动作都提供并写清楚分开**：「回滚」=保留数据（Part A 制品切版本）；「重置/重装」=丢弃数据（销毁重建到镜像）。

--- a/docs/worker-artifact-update.md
+++ b/docs/worker-artifact-update.md
@@ -4,6 +4,10 @@
 `update/worker/<version>/`，并触发 `.github/workflows/worker-image.yml` 自动 bake
 云镜像。正常发布无需手动触发；`workflow_dispatch` 仅用于补发或故障恢复。
 
+Release CD 会在发布成功后清理 `catsco-worker-release` 应用制品，只保留最近三个
+版本；较旧且至少存在一天的完整版本才会删除。因此控制面用于更新和回滚的应用
+版本列表与镜像历史都保持在最近三个以内。
+
 已有云员工由控制面获取私有制品并调用 `scripts/update-worker-artifact.sh`。更新器
 只修改 `/opt/catsco/releases` 与 `/opt/catsco/current`，重启并验证服务，失败自动
 回滚；`/srv/catsco-agent` 用户数据、会话、技能和凭据不受影响。

--- a/ops/ctyun-worker-image/Manage-WorkerImages.ps1
+++ b/ops/ctyun-worker-image/Manage-WorkerImages.ps1
@@ -4,7 +4,7 @@ Worker 私有镜像生命周期管理（与 New-CatsCoWorkerImage.ps1 配套）�
 
   -List   : 列出全部 catsco-worker-* 私有镜像（imageID/name/version/commit/createdTime）
   -Latest : 输出最新 bake 的 worker 镜像 imageID（供部署/控制面取最新镜像）
-  -Prune  : 保留最新 N 个（默认 6），删除更旧的（带 bake label 的 catsco-worker-*），
+  -Prune  : 保留最新 N 个（默认 3），删除更旧的（带 bake label 的 catsco-worker-*），
             删除需连续空读确认（按 --imageName 精确过滤，避免 >200 张时最旧镜像
             不在第 1 页导致的误判），确认超时可配（-ConfirmTimeoutMinutes），
             失败 fail-closed 聚合报告
@@ -26,7 +26,7 @@ param(
     [string]$Action = "List",
 
     [ValidateRange(1, 50)]
-    [int]$Keep = 6,
+    [int]$Keep = 3,
 
     [ValidateRange(1, 30)]
     [int]$ConfirmTimeoutMinutes = 3,

--- a/ops/ctyun-worker-image/README.md
+++ b/ops/ctyun-worker-image/README.md
@@ -59,13 +59,13 @@ application releases while still allowing new workers to start without GitHub.
   > this `.ps1`.
 - `-Action Latest` : print the newest imageID (used by deployment to pick the
   latest image)
-- `-Action Prune`  : keep the newest `-Keep` images (default 6) and delete
+- `-Action Prune`  : keep the newest `-Keep` images (default 3) and delete
   older bake-labeled `catsco-worker-*` images; each deletion is confirmed by a
   name-scoped `ListImage` read, and failures fail closed.
   Requires `-ProtectedImageIDs` (comma-separated) when there are images to
   delete — protected images are never deleted.
 
-CI runs `Prune -Keep 6` after every successful bake (`continue-on-error`,
+CI runs `Prune -Keep 3` after every successful bake (`continue-on-error`,
 30-minute budget), passing `$env:WORKER_PROTECTED_IMAGE_IDS` (repo var
 `CTYUN_WORKER_PROTECTED_IMAGE_IDS`).
 
@@ -75,7 +75,7 @@ CI runs `Prune -Keep 6` after every successful bake (`continue-on-error`,
   launch template, plus any pinned rollback/staged-rollout target. The script
   only verifies the list is non-empty; it does not auto-discover the template
   reference, so keep it in sync when the template moves.
-- **Local invocation**: `./Manage-WorkerImages.ps1 -Action Prune -Keep 6
+- **Local invocation**: `./Manage-WorkerImages.ps1 -Action Prune -Keep 3
   -RegionID <region> -ProjectID 0 -ProtectedImageIDs
   "<imageID1>,<imageID2>"`.
 - **Rotating / emergency**: after a bake that becomes the new production

--- a/scripts/plan-release-retention.mjs
+++ b/scripts/plan-release-retention.mjs
@@ -6,6 +6,7 @@ import yaml from 'js-yaml';
 const DAY_MS = 24 * 60 * 60 * 1000;
 
 const RELEASE_PATTERNS = [
+  /^update\/worker\/([^/]+)\/[^/]+$/,
   /^update\/CatsCo-(.+)-win\.exe(?:\.blockmap)?$/,
   /^update\/CatsCo-(.+)-linux\.(?:AppImage|deb)(?:\.blockmap)?$/,
   /^update\/macos-(x64|arm64)\/CatsCo-(.+)-mac-\1\.(?:dmg|zip)(?:\.blockmap)?$/,

--- a/tests/manage-worker-images.test.ts
+++ b/tests/manage-worker-images.test.ts
@@ -83,7 +83,7 @@ process.stdout.write(JSON.stringify({
 }));
 `;
 
-test("worker image lifecycle: list, latest, and prune keeps N (default 6)", () => {
+test("worker image lifecycle: list, latest, and prune keeps N (default 3)", () => {
   const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "catsco-img-mgmt-"));
   try {
     const statePath = path.join(sandbox, "state.json");
@@ -194,10 +194,10 @@ process.exit(result.status ?? 1);
     );
     assert.equal(latestResult.stdout.trim(), "img-08");
 
-    // --- Prune 6: deletes the 2 oldest, keeps 6 (protected list declared) ---
+    // --- Prune 3: deletes the 5 oldest, keeps 3 (protected list declared) ---
     writeState();
     fs.rmSync(logPath, { force: true });
-    const pruneResult = runScript("Prune", ["-Keep", "6", "-ProtectedImageIDs", "img-000"]);
+    const pruneResult = runScript("Prune", ["-Keep", "3", "-ProtectedImageIDs", "img-000"]);
     assert.equal(
       pruneResult.status,
       0,
@@ -210,14 +210,14 @@ process.exit(result.status ?? 1);
       i.imageName.startsWith("catsco-worker-") &&
       i.labels.some((l: any) => l.labelKey === "bake"),
     );
-    assert.equal(remaining.length, 6);
+    assert.equal(remaining.length, 3);
     assert.ok(!remaining.some((i: any) => i.imageID === "img-01"));
     assert.ok(!remaining.some((i: any) => i.imageID === "img-02"));
     // unrelated and no-bake images untouched
     assert.ok(prunedState.images.some((i: any) => i.imageID === "img-other"));
     assert.ok(prunedState.images.some((i: any) => i.imageID === "img-nobake"));
 
-    // --- Prune 6 with only 5 -> nothing to delete ---
+    // --- Prune 3 with only 5 -> nothing to delete ---
     writeState({
       images: images.slice(0, 5),
     });
@@ -231,10 +231,10 @@ process.exit(result.status ?? 1);
     const noOpCalls = fs.readFileSync(logPath, "utf8");
     assert.doesNotMatch(noOpCalls, /ims DeleteImage/);
 
-    // --- Prune with a delete failure -> fail closed, keeps others ---
+    // --- Prune 3 with a delete failure -> fail closed, keeps others ---
     writeState({ deleteFailures: ["img-01"] });
     fs.rmSync(logPath, { force: true });
-    const failResult = runScript("Prune", ["-Keep", "6", "-ProtectedImageIDs", "img-000"]);
+    const failResult = runScript("Prune", ["-Keep", "3", "-ProtectedImageIDs", "img-000"]);
     assert.notEqual(failResult.status, 0);
     assert.match(failResult.stderr, /Worker image cleanup failed/);
     const failCalls = fs.readFileSync(logPath, "utf8");
@@ -336,7 +336,7 @@ test("worker image lifecycle: multi-round confirm, pagination, and confirm timeo
     const eight = workerImages(8);
     sb.writeState(eight, { deleteDelayRounds: { "img-001": 3 } });
     fs.rmSync(sb.logPath, { force: true });
-    const pruneRes = sb.runScript("Prune", ["-Keep", "6", "-ProtectedImageIDs", "img-000"]);
+    const pruneRes = sb.runScript("Prune", ["-Keep", "3", "-ProtectedImageIDs", "img-000"]);
     assert.equal(pruneRes.status, 0, `${pruneRes.stdout}\n${pruneRes.stderr}`);
     const pruned = JSON.parse(fs.readFileSync(sb.statePath, "utf8"));
     assert.ok(!pruned.images.some((i: any) => i.imageID === "img-001"), "delayed image must still be removed");
@@ -406,7 +406,7 @@ test("worker image lifecycle: prune protects production-referenced images", () =
     // --- protected oldest image survives prune ---
     sb.writeState(eight, {});
     fs.rmSync(sb.logPath, { force: true });
-    const r = sb.runScript("Prune", ["-Keep", "6", "-ProtectedImageIDs", "img-001"]);
+    const r = sb.runScript("Prune", ["-Keep", "3", "-ProtectedImageIDs", "img-001"]);
     assert.equal(r.status, 0, `${r.stdout}\n${r.stderr}`);
     const state = JSON.parse(fs.readFileSync(sb.statePath, "utf8"));
     const remaining = state.images.filter((i: any) => i.labels?.some((l: any) => l.labelKey === "bake"));
@@ -423,7 +423,7 @@ test("worker image lifecycle: prune protects production-referenced images", () =
     // --- no protected list configured -> refuse (fail closed) ---
     sb.writeState(eight, {});
     fs.rmSync(sb.logPath, { force: true });
-    const r3 = sb.runScript("Prune", ["-Keep", "6"]);
+    const r3 = sb.runScript("Prune", ["-Keep", "3"]);
     assert.notEqual(r3.status, 0, `expected refusal:\n${r3.stdout}\n${r3.stderr}`);
     assert.match(r3.stderr, /no protected image IDs configured/);
     assert.doesNotMatch(fs.readFileSync(sb.logPath, "utf8"), /ims DeleteImage/);

--- a/tests/release-retention-plan.test.ts
+++ b/tests/release-retention-plan.test.ts
@@ -23,6 +23,14 @@ function release(version: string, modified = oldDate) {
   ];
 }
 
+function workerRelease(version: string, modified = oldDate) {
+  return [
+    object(`update/worker/${version}/catsco-worker-${version}-linux-x64.tar.gz`, modified),
+    object(`update/worker/${version}/catsco-worker-${version}-linux-x64.tar.gz.sha256`, modified),
+    object(`update/worker/${version}/manifest.json`, modified),
+  ];
+}
+
 test('semantic versions sort numerically', () => {
   assert.equal(compareReleaseVersions('1.10.0', '1.9.9') > 0, true);
   assert.equal(compareReleaseVersions('1.4.8', '1.4.8-beta.1') > 0, true);
@@ -50,7 +58,7 @@ test('protects current metadata and the newest two complete releases', () => {
   assert.deepEqual(plan.deleteVersions, ['1.0.1', '1.1.0', '1.4.6']);
   assert.equal(plan.deleteObjects.length, 15);
   assert.equal(plan.deleteObjects.some((row) => row.key.includes('1.4.8')), false);
-  assert.deepEqual(plan.ignoredKeys.sort(), ['update/latest.yml', 'update/worker/1.4.8/manifest.json']);
+  assert.deepEqual(plan.ignoredKeys.sort(), ['update/latest.yml']);
 });
 
 test('does not delete a release with any recently republished artifact', () => {
@@ -85,4 +93,23 @@ test('deletion cap never splits a release group', () => {
   assert.deepEqual(plan.deleteVersions, ['1.0.0']);
   assert.deepEqual(plan.deferredVersions, ['1.0.1']);
   assert.equal(plan.deleteObjects.length, 5);
+});
+
+test('worker artifacts are grouped and retain the newest three versions', () => {
+  const plan = buildReleaseRetentionPlan({
+    objects: [
+      ...workerRelease('1.5.7'),
+      ...workerRelease('1.5.6'),
+      ...workerRelease('1.5.5'),
+      ...workerRelease('1.5.4'),
+    ],
+    keepVersions: 3,
+    minAgeDays: 1,
+    maxDeleteObjects: 20,
+    now,
+  });
+
+  assert.deepEqual(plan.protectedVersions, ['1.5.7', '1.5.6', '1.5.5']);
+  assert.deepEqual(plan.deleteVersions, ['1.5.4']);
+  assert.equal(plan.deleteObjects.length, 3);
 });

--- a/tests/worker-release-artifact-workflow.test.ts
+++ b/tests/worker-release-artifact-workflow.test.ts
@@ -64,6 +64,19 @@ test('desktop releases are pruned only after publication with bounded retention'
   assert.match(releaseWorkflow, /One or more old \$label release objects still exist/);
 });
 
+test('worker application releases are pruned after publication with three-version retention', () => {
+  const releaseJob = releaseWorkflow.match(/\r?\n  release:\r?\n[\s\S]*$/)?.[0] || '';
+
+  assert.match(releaseJob, /- name: Prune old worker application releases/);
+  assert.match(releaseJob, /--prefix update\/worker\//);
+  assert.match(releaseJob, /--keep-versions 3/);
+  assert.match(releaseJob, /--min-age-days 1/);
+  assert.match(releaseJob, /--max-delete-objects 40/);
+  assert.match(releaseJob, /TOS_WORKER_BUCKET/);
+  assert.match(releaseJob, /worker-delete-result\.json/);
+  assert.match(releaseJob, /newest three versions were preserved/);
+});
+
 test('worker artifacts never enter the public release paths', () => {
   const publicSourceUpload = releaseWorkflow.match(
     /- name: Upload release payloads to Hong Kong source bucket[\s\S]*?- name: Wait for Guangzhou bucket replication/,


### PR DESCRIPTION
## 变更\n- 镜像清理默认及 CI 保留最近 3 个版本，适用于华南 2 private_nat 与佛山 7 public_ip 两条制镜链路。\n- Release CD 为 catsco-worker-release 应用制品增加版本级清理，保留最近 3 个完整版本，旧版本至少存放 1 天后删除。\n- 扩展保留计划器识别 worker 制品，并补充镜像、应用桶和工作流测试。\n\n## 验证\n- npx tsx --test tests/manage-worker-images.test.ts tests/release-retention-plan.test.ts tests/worker-release-artifact-workflow.test.ts\n- 14/14 targeted tests passed\n\n需要在合并后由 vX.Y.Z tag 触发 Release CD，真实核对应用桶和两区域镜像列表。